### PR TITLE
Add nl

### DIFF
--- a/_gtfobins/nl.md
+++ b/_gtfobins/nl.md
@@ -1,0 +1,5 @@
+---
+functions:
+  file-read:
+    - code: nl -bn -w1 file_to_read
+---


### PR DESCRIPTION
Note: There are a gazillion shell utils (like `nl` in this PR) that allow some kind of file-read, maybe not in a format identical to the original but that important info can be understood, like:

* sort -m file_to_read
* od, xxd, hexdump
* ul
* groff (input will be invalid groff format, but still you can figure it out in the output)
* join (for example join a file with itself)
* uniq (when you don't care about duplicate line, like: `uniq /etc/passwd`)
* iconv

should we add an entry for each of those?