### PR TITLE
add openssl-enc commands

### DIFF
--- a/_gtfobins/openssl.md
+++ b/_gtfobins/openssl.md
@@ -1,0 +1,24 @@
+---
+functions:
+  file-write:
+    - code: |
+        LFILE=file_to_write
+        echo DATA | openssl enc -out "$LFILE"
+    - code: |
+        LFILE=file_to_write
+        TF=$(mktemp)
+        echo "DATA" > $TF
+        openssl enc -in "$TF" -out "$LFILE"
+  file-read:
+    - code: |
+        LFILE=file_to_read
+        openssl enc -in "$LFILE"
+  suid:
+    - code: |
+        LFILE=file_to_read
+        openssl enc -in "$LFILE"
+  sudo:
+    - code: |
+        LFILE=file_to_read
+        sudo openssl enc -in "$LFILE"
+---

--- a/_gtfobins/openssl.md
+++ b/_gtfobins/openssl.md
@@ -15,10 +15,10 @@ functions:
         openssl enc -in "$LFILE"
   suid:
     - code: |
-        LFILE=file_to_read
-        openssl enc -in "$LFILE"
+        LFILE=file_to_write
+        echo DATA | openssl enc -out "$LFILE"
   sudo:
     - code: |
-        LFILE=file_to_read
-        sudo openssl enc -in "$LFILE"
+        LFILE=file_to_write
+        echo DATA | sudo openssl enc -out "$LFILE"
 ---


### PR DESCRIPTION
conformation tests: 
```bash
# junk data
DATA="testing, testing, 1, 2, 3, ..."
# can write to file
echo "$DATA" | openssl enc -out /tmp/testing1
# can use sudo to write to protected folder
echo "$DATA" | sudo openssl enc -out /root/testing2
# set suid on command
sudo chmod u+s `which openssl`
# can write to file maintaining suid environment
echo "$DATA" | openssl enc -out /tmp/testing3
# can read from a protected folder with suid environment
openssl enc -in /root/testing2
# unset suid on command
sudo chmod u-s `which openssl`
# verify files exits and user/group ownership
sudo ls -l /tmp/testing* /root/testing2 | awk '{ print $1, $3, $4, $9 }'
```
last command should match
```
-rw-r--r-- root root /root/testing2
-rw-r--r-- user user /tmp/testing1
-rw-r--r-- root user /tmp/testing3
```