### PR TITLE
fix typo in shell name

### DIFF
--- a/_gtfobins/dash.md
+++ b/_gtfobins/dash.md
@@ -5,7 +5,7 @@ functions:
   file-write:
     - code: |
         export LFILE=file_to_write
-        ash -c 'echo DATA > $LFILE'
+        dash -c 'echo DATA > $LFILE'
   suid:
     - code: ./dash -p
   sudo:


### PR DESCRIPTION
The `ash` shell was used instead of `dash`.