### PR TITLE
add missing spaces

### DIFF
--- a/_gtfobins/fmt.md
+++ b/_gtfobins/fmt.md
@@ -2,15 +2,30 @@
 description: The read file content is not binary-safe.
 functions:
   file-read:
-    - code: |
+    - description: This only works for the GNU version of `fmt`.
+      code: |
         LFILE=file_to_read
-        fmt -p NON_EXISTING_PREFIX "$LFILE"
+        fmt -pNON_EXISTING_PREFIX "$LFILE"
+    - description: This corrupts the output by wrapping very long lines at the given width.
+      code: |
+        LFILE=file_to_read
+        fmt -999 "$LFILE"
   suid:
-    - code: |
+    - description: This only works for the GNU version of `fmt`.
+      code: |
         LFILE=file_to_read
-        ./fmt -p NON_EXISTING_PREFIX "$LFILE"
+        ./fmt -pNON_EXISTING_PREFIX "$LFILE"
+    - description: This corrupts the output by wrapping very long lines at the given width.
+      code: |
+        LFILE=file_to_read
+        ./fmt -999 "$LFILE"
   sudo:
-    - code: |
+    - description: This only works for the GNU version of `fmt`.
+      code: |
         LFILE=file_to_read
-        sudo fmt -p NON_EXISTING_PREFIX "$LFILE"
+        sudo fmt -pNON_EXISTING_PREFIX "$LFILE"
+    - description: This corrupts the output by wrapping very long lines at the given width. 
+      code: |
+        LFILE=file_to_read
+        sudo fmt -999 "$LFILE"
 ---

--- a/_gtfobins/fmt.md
+++ b/_gtfobins/fmt.md
@@ -4,13 +4,13 @@ functions:
   file-read:
     - code: |
         LFILE=file_to_read
-        fmt -pNON_EXISTING_PREFIX "$LFILE"
+        fmt -p NON_EXISTING_PREFIX "$LFILE"
   suid:
     - code: |
         LFILE=file_to_read
-        ./fmt -pNON_EXISTING_PREFIX "$LFILE"
+        ./fmt -p NON_EXISTING_PREFIX "$LFILE"
   sudo:
     - code: |
         LFILE=file_to_read
-        sudo fmt -pNON_EXISTING_PREFIX "$LFILE"
+        sudo fmt -p NON_EXISTING_PREFIX "$LFILE"
 ---

--- a/_gtfobins/fmt.md
+++ b/_gtfobins/fmt.md
@@ -11,20 +11,12 @@ functions:
         LFILE=file_to_read
         fmt -999 "$LFILE"
   suid:
-    - description: This only works for the GNU version of `fmt`.
-      code: |
-        LFILE=file_to_read
-        ./fmt -pNON_EXISTING_PREFIX "$LFILE"
     - description: This corrupts the output by wrapping very long lines at the given width.
       code: |
         LFILE=file_to_read
         ./fmt -999 "$LFILE"
   sudo:
-    - description: This only works for the GNU version of `fmt`.
-      code: |
-        LFILE=file_to_read
-        sudo fmt -pNON_EXISTING_PREFIX "$LFILE"
-    - description: This corrupts the output by wrapping very long lines at the given width. 
+    - description: This corrupts the output by wrapping very long lines at the given width.
       code: |
         LFILE=file_to_read
         sudo fmt -999 "$LFILE"


### PR DESCRIPTION
The spaces are missing between the `-p` option and `NON_EXISTING_PREFIX` value.