### PR TITLE
Create sg.md

### DIFF
--- a/_gtfobins/sg.md
+++ b/_gtfobins/sg.md
@@ -1,6 +1,6 @@
 ---
 functions:
-  shell:  
+  shell:
     - description: Commands can be run if the current user's group is specified, therefore no additional permissions are needed.
       code: |
         GROUPNAME=users
@@ -8,7 +8,7 @@ functions:
   command:
     - description: Commands can be run if the current user's group is specified, therefore no additional permissions are needed.
       code: |
-        COMMAND=whoami   
+        COMMAND=whoami
         GROUPNAME=users
         sg $GROUPNAME -c $COMMAND
   sudo:

--- a/_gtfobins/sg.md
+++ b/_gtfobins/sg.md
@@ -1,0 +1,19 @@
+---
+functions:
+  shell:  
+    - description: Commands can be run if the current user's group is specified, therefore no additional permissions are needed.
+      code: |
+        GROUPNAME=users
+        sg $GROUPNAME -c "/bin/sh"
+  command:
+    - description: Commands can be run if the current user's group is specified, therefore no additional permissions are needed.
+      code: |
+        COMMAND=whoami   
+        GROUPNAME=users
+        sg $GROUPNAME -c $COMMAND
+  sudo:
+    - description: Any group can be specified as the user will have root permissions.
+      code: |
+        GROUPNAME=users
+        sudo sg $GROUPNAME -c "/bin/sh"
+---

--- a/_gtfobins/sg.md
+++ b/_gtfobins/sg.md
@@ -3,17 +3,8 @@ functions:
   shell:
     - description: Commands can be run if the current user's group is specified, therefore no additional permissions are needed.
       code: |
-        GROUPNAME=users
-        sg $GROUPNAME -c "/bin/sh"
-  command:
-    - description: Commands can be run if the current user's group is specified, therefore no additional permissions are needed.
-      code: |
-        COMMAND=whoami
-        GROUPNAME=users
-        sg $GROUPNAME -c $COMMAND
+        sg $(id -ng)
   sudo:
-    - description: Any group can be specified as the user will have root permissions.
-      code: |
-        GROUPNAME=users
-        sudo sg $GROUPNAME -c "/bin/sh"
+    - code: |
+        sudo sg root
 ---


### PR DESCRIPTION
Adding the "sg" binary which allows command execution under a "different" group ID. However, it can be used to break out of restricted environments by using a user's own group ID.