### PR TITLE
fix iftop version

### DIFF
--- a/_gtfobins/iftop.md
+++ b/_gtfobins/iftop.md
@@ -1,5 +1,5 @@
 ---
-description: This requires `iftop` 1.17 and the privilege to capture on some device (specify with `-i` if needed) .
+description: This requires `iftop` 0.17 and the privilege to capture on some device (specify with `-i` if needed) .
 functions:
   shell:
     - code: |


### PR DESCRIPTION
### Little Mistype

Hi,
The exploitable version of iftop is `0.17` and not `1.17`. 
In fact, the last iftop version is `1.0pre4`, and the last stable version is `0.17`

Have a good day !