### PR TITLE
Portable GTFOBins

### DIFF
--- a/_gtfobins/apt-get.md
+++ b/_gtfobins/apt-get.md
@@ -1,12 +1,12 @@
 ---
 functions:
   shell:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         apt-get changelog apt
         !/bin/sh
   sudo:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo apt-get changelog apt
         !/bin/sh

--- a/_gtfobins/apt.md
+++ b/_gtfobins/apt.md
@@ -1,12 +1,12 @@
 ---
 functions:
   shell:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         apt changelog apt
         !/bin/sh
   sudo:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo apt changelog apt
         !/bin/sh

--- a/_gtfobins/bundler.md
+++ b/_gtfobins/bundler.md
@@ -1,7 +1,7 @@
 ---
 functions:
   shell:
-    - description: This invokes the default pager, which is likely to be  [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be  [`less`](../less/index.html), other functions may apply.
       code: |
         bundler help
         !/bin/sh
@@ -13,7 +13,7 @@ functions:
         touch $TF/Gemfile
         cd $TF
         bundler exec /bin/sh
-    - description: This spawns an interactive shell via [`irb`](/gtfobins/irb/).
+    - description: This spawns an interactive shell via [`irb`](../irb/index.html).
       code: |
         TF=$(mktemp -d)
         touch $TF/Gemfile
@@ -26,7 +26,7 @@ functions:
         cd $TF
         bundler install
   sudo:
-    - description: This invokes the default pager, which is likely to be  [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be  [`less`](../less/index.html), other functions may apply.
       code: |
         sudo bundler help
         !/bin/sh

--- a/_gtfobins/busctl.md
+++ b/_gtfobins/busctl.md
@@ -1,5 +1,5 @@
 ---
-description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/cowsay.md
+++ b/_gtfobins/cowsay.md
@@ -1,5 +1,5 @@
 ---
-description: It allows to execute [`perl`](/gtfobins/perl) code, other functions may apply.
+description: It allows to execute [`perl`](../perl) code, other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/cowsay.md
+++ b/_gtfobins/cowsay.md
@@ -1,5 +1,5 @@
 ---
-description: It allows to execute [`perl`](../perl) code, other functions may apply.
+description: It allows to execute [`perl`](../perl/index.html) code, other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/cowthink.md
+++ b/_gtfobins/cowthink.md
@@ -1,5 +1,5 @@
 ---
-description: It allows to execute [`perl`](/gtfobins/perl) code, other functions may apply.
+description: It allows to execute [`perl`](../perl) code, other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/cowthink.md
+++ b/_gtfobins/cowthink.md
@@ -1,5 +1,5 @@
 ---
-description: It allows to execute [`perl`](../perl) code, other functions may apply.
+description: It allows to execute [`perl`](../perl/index.html) code, other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/crash.md
+++ b/_gtfobins/crash.md
@@ -1,7 +1,7 @@
 ---
 functions:
   shell:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         crash -h
         !sh
@@ -10,7 +10,7 @@ functions:
         COMMAND='/usr/bin/id'
         CRASHPAGER="$COMMAND" crash -h
   sudo:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo crash -h
         !sh

--- a/_gtfobins/dmesg.md
+++ b/_gtfobins/dmesg.md
@@ -6,12 +6,12 @@ functions:
         LFILE=file_to_read
         dmesg -rF "$LFILE"
   shell:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         dmesg -H
         !/bin/sh
   sudo:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo dmesg -H
         !/bin/sh

--- a/_gtfobins/dpkg.md
+++ b/_gtfobins/dpkg.md
@@ -1,12 +1,12 @@
 ---
 functions:
   shell:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         dpkg -l
         !/bin/sh
   sudo:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo dpkg -l
         !/bin/sh

--- a/_gtfobins/eb.md
+++ b/_gtfobins/eb.md
@@ -1,5 +1,5 @@
 ---
-description: This invokes the default logging service, which is likely to be [`journalctl`](/gtfobins/journalctl/), other functions may apply. For this to work the target must be connected to AWS instance via EB-CLI.
+description: This invokes the default logging service, which is likely to be [`journalctl`](../journalctl/index.html), other functions may apply. For this to work the target must be connected to AWS instance via EB-CLI.
 functions:
   shell:
     - code: |

--- a/_gtfobins/gem.md
+++ b/_gtfobins/gem.md
@@ -3,16 +3,16 @@ functions:
   shell:
     - description: This requires the name of an installed gem to be provided (`rdoc` is usually installed).
       code: gem open -e "/bin/sh -c /bin/sh" rdoc
-    - description: This invokes the default editor, which is likely to be [`vi`](/gtfobins/vi/), other functions may apply. This requires the name of an installed gem to be provided (`rdoc` is usually installed).
+    - description: This invokes the default editor, which is likely to be [`vi`](../vi/index.html), other functions may apply. This requires the name of an installed gem to be provided (`rdoc` is usually installed).
       code: |
         gem open rdoc
         :!/bin/sh
-    - description: This executes the specified file as [`ruby`](/gtfobins/ruby/) code.
+    - description: This executes the specified file as [`ruby`](../ruby/index.html) code.
       code: |
         TF=$(mktemp -d)
         echo 'system("/bin/sh")' > $TF/x
         gem build $TF/x
-    - description: This executes the specified file as [`ruby`](/gtfobins/ruby/) code.
+    - description: This executes the specified file as [`ruby`](../ruby/index.html) code.
       code: |
         TF=$(mktemp -d)
         echo 'system("/bin/sh")' > $TF/x

--- a/_gtfobins/git.md
+++ b/_gtfobins/git.md
@@ -2,11 +2,11 @@
 functions:
   shell:
     - code: PAGER='sh -c "exec sh 0<&1"' git -p help
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         git help config
         !/bin/sh
-    - description: The help system can also be reached from any `git` command, e.g., `git branch`. This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: The help system can also be reached from any `git` command, e.g., `git branch`. This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         git branch --help config
         !/bin/sh
@@ -28,11 +28,11 @@ functions:
         git diff /dev/null $LFILE
   sudo:
     - code: sudo PAGER='sh -c "exec sh 0<&1"' git -p help
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo git -p help config
         !/bin/sh
-    - description: The help system can also be reached from any `git` command, e.g., `git branch`. This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: The help system can also be reached from any `git` command, e.g., `git branch`. This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo git branch --help config
         !/bin/sh

--- a/_gtfobins/journalctl.md
+++ b/_gtfobins/journalctl.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+  This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
 
   This might not work if run by unprivileged users depending on the system configuration.
 functions:

--- a/_gtfobins/knife.md
+++ b/_gtfobins/knife.md
@@ -1,5 +1,5 @@
 ---
-description: This is capable of running [`ruby`](/gtfobins/ruby/) code.
+description: This is capable of running [`ruby`](../ruby/index.html) code.
 functions:
   shell:
     - code: |

--- a/_gtfobins/latexmk.tex
+++ b/_gtfobins/latexmk.tex
@@ -1,4 +1,4 @@
-description: This allows to execute [`perl`](/gtfobins/perl/) code.
+description: This allows to execute [`perl`](../perl/index.html) code.
 functions:
   shell:
     - code: latexmk -e 'exec "/bin/sh";'

--- a/_gtfobins/loginctl.md
+++ b/_gtfobins/loginctl.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+  This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
 
   This might not work if run by unprivileged users depending on the system configuration.
 functions:

--- a/_gtfobins/lualatex.md
+++ b/_gtfobins/lualatex.md
@@ -1,5 +1,5 @@
 ---
-description: This allows to execute [`lua`](/gtfobins/lua/) code.
+description: This allows to execute [`lua`](../lua/index.html) code.
 functions:
   shell:
     - code: lualatex -shell-escape '\documentclass{article}\begin{document}\directlua{os.execute("/bin/sh")}\end{document}'

--- a/_gtfobins/luatex.md
+++ b/_gtfobins/luatex.md
@@ -1,5 +1,5 @@
 ---
-description: This allows to execute [`lua`](/gtfobins/lua/) code.
+description: This allows to execute [`lua`](../lua/index.html) code.
 functions:
   shell:
     - code: luatex -shell-escape '\directlua{os.execute("/bin/sh")}\end'

--- a/_gtfobins/man.md
+++ b/_gtfobins/man.md
@@ -1,5 +1,5 @@
 ---
-description: This invokes the default pager, which is likely to be  [`less`](/gtfobins/less/), other functions may apply.
+description: This invokes the default pager, which is likely to be  [`less`](../less/index.html), other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/pdb.md
+++ b/_gtfobins/pdb.md
@@ -1,5 +1,5 @@
 ---
-description: This allows to execute [`python`](/gtfobins/python/) code, other functions may apply.
+description: This allows to execute [`python`](../python/index.html) code, other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/psql.md
+++ b/_gtfobins/psql.md
@@ -1,5 +1,5 @@
 ---
-description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
 functions:
   shell:
     - code: |

--- a/_gtfobins/restic.md
+++ b/_gtfobins/restic.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  The attacker must setup a server to receive the backups, in the following example [rest-server](https://github.com/restic/rest-server/) is used but there are other options. To start a new instance and create a new repository:
+  The attacker must setup a server to receive the backups, in the following example [rest-server](https://github.com/restic/rest-server/index.html) is used but there are other options. To start a new instance and create a new repository:
 
   ```console
   RPORT=12345

--- a/_gtfobins/run-mailcap.md
+++ b/_gtfobins/run-mailcap.md
@@ -1,21 +1,21 @@
 ---
 functions:
   shell:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         run-mailcap --action=view /etc/hosts
         !/bin/sh
   file-read:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: run-mailcap --action=view file_to_read
   file-write:
     - description: |
         The file must exist and be not empty.
 
-        This invokes the default editor, which is likely to be [`vi`](/gtfobins/vi/), other functions may apply.
+        This invokes the default editor, which is likely to be [`vi`](../vi/index.html), other functions may apply.
       code: run-mailcap --action=edit file_to_read
   sudo:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo run-mailcap --action=view /etc/hosts
         !/bin/sh

--- a/_gtfobins/systemctl.md
+++ b/_gtfobins/systemctl.md
@@ -25,7 +25,7 @@ functions:
         WantedBy=multi-user.target' > $TF
         sudo systemctl link $TF
         sudo systemctl enable --now $TF
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo systemctl
         !sh

--- a/_gtfobins/systemd-resolve.md
+++ b/_gtfobins/systemd-resolve.md
@@ -1,7 +1,7 @@
 ---
 functions:
   sudo:
-    - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+    - description: This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
       code: |
         sudo systemd-resolve --status
         !sh

--- a/_gtfobins/timedatectl.md
+++ b/_gtfobins/timedatectl.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.
+  This invokes the default pager, which is likely to be [`less`](../less/index.html), other functions may apply.
 
   This might not work if run by unprivileged users depending on the system configuration.
 functions:

--- a/_gtfobins/tshark.md
+++ b/_gtfobins/tshark.md
@@ -1,5 +1,5 @@
 ---
-description: This program is able to execute [`lua`](/gtfobins/less/) code.
+description: This program is able to execute [`lua`](../less/index.html) code.
 functions:
   shell:
     - code: |

--- a/_gtfobins/vi.md
+++ b/_gtfobins/vi.md
@@ -1,5 +1,5 @@
 ---
-description: Modern Unix systems run [`vim`](/gtfobins/vim/) binary when `vi` is called.
+description: Modern Unix systems run [`vim`](../vim/index.html) binary when `vi` is called.
 functions:
   shell:
     - code: vi -c ':!/bin/sh' /dev/null

--- a/_gtfobins/vigr.md
+++ b/_gtfobins/vigr.md
@@ -1,5 +1,5 @@
 ---
-description: This command allows to edit some designated files (`/etc/passwd`, `/etc/group`, `/etc/shadow` and `/etc/gshadow`) safely by spawning the default editor (falling back to [`vim`](/gtfobins/vim/), other functions may apply). Despite requiring superuser privileges to run, the editor is executed as the unprivileged user when run as SUID or with `sudo`.
+description: This command allows to edit some designated files (`/etc/passwd`, `/etc/group`, `/etc/shadow` and `/etc/gshadow`) safely by spawning the default editor (falling back to [`vim`](../vim/index.html), other functions may apply). Despite requiring superuser privileges to run, the editor is executed as the unprivileged user when run as SUID or with `sudo`.
 functions:
   suid:
     - code: ./vigr

--- a/_gtfobins/vipw.md
+++ b/_gtfobins/vipw.md
@@ -1,5 +1,5 @@
 ---
-description: This command allows to edit some designated files (`/etc/passwd`, `/etc/group`, `/etc/shadow` and `/etc/gshadow`) safely by spawning the default editor (falling back to [`vim`](/gtfobins/vim/), other functions may apply). Despite requiring superuser privileges to run, the editor is executed as the unprivileged user when run as SUID or with `sudo`.
+description: This command allows to edit some designated files (`/etc/passwd`, `/etc/group`, `/etc/shadow` and `/etc/gshadow`) safely by spawning the default editor (falling back to [`vim`](../vim/index.html), other functions may apply). Despite requiring superuser privileges to run, the editor is executed as the unprivileged user when run as SUID or with `sudo`.
 functions:
   suid:
     - code: ./vipw

--- a/_includes/base.html
+++ b/_includes/base.html
@@ -1,0 +1,11 @@
+{% assign base = '' %}
+{% assign depth = page.url | split: '/' | size %}
+{% if depth <= 1 %}
+    {% assign base = '.' %}
+{% elsif depth == 2 %}
+    {% assign base = '..' %}
+{% elsif depth == 3 %}
+    {% assign base = '../..' %}
+{% elsif depth == 4 %}
+    {% assign base = '../../..' %}
+{% endif %}

--- a/_includes/bin_table.html
+++ b/_includes/bin_table.html
@@ -1,12 +1,11 @@
 <div id="bin-search-wrapper">
     <ul id="bin-search-filters" class="function-list">
         {% for function_pair in site.data.functions %}
-        {% assign function_id = function_pair[0] %}
-        {% assign function = function_pair[1] %}
-        <li><a href="#+{{ function.label | downcase }}" data-title="{{ function.description | replace: '\n', ' ' }}">{{ function.label }}</a></li>
+            {% assign function_id = function_pair[0] %}
+            {% assign function = function_pair[1] %}
+            <li><a href="#+{{ function.label | downcase }}" data-title="{{ function.description | replace: '\n', ' ' }}">{{ function.label }}</a></li>
         {% endfor %}
     </ul>
-
     <input id="bin-search" type="text" placeholder="Search among {{ site.gtfobins | size }} binaries: <binary> +<function> ..."/>
 </div>
 
@@ -19,9 +18,10 @@
             </tr>
         </thead>
         <tbody>
+            {% include base.html %}
             {% for file in site.gtfobins %}
             <tr>
-                <td><a href="{{ file.url }}" class="bin-name">{% include get_bin_name path=file.path %}</a></td>
+                <td><a href="{{ base }}{{ file.url }}index.html" class="bin-name">{% include get_bin_name path=file.path %}</a></td>
                 <td>{% include function_list.html bin=file %}</td>
             </tr>
             {% endfor %}

--- a/_includes/function_list.html
+++ b/_includes/function_list.html
@@ -1,8 +1,9 @@
 <ul class="function-list">
+    {% include base.html %}
     {% for function_pair in site.data.functions %}
-    {% assign function_id = function_pair[0] %}
-    {% assign function = function_pair[1] %}
-    {% unless include.bin.functions[function_id] %}{% continue %}{% endunless %}
-    <li><a href="{{ include.bin.url }}#{{ function_id }}">{{ function.label }}</a></li>
+        {% assign function_id = function_pair[0] %}
+        {% assign function = function_pair[1] %}
+        {% unless include.bin.functions[function_id] %}{% continue %}{% endunless %}
+        <li><a href="{{ base }}{{ include.bin.url }}index.html#{{ function_id }}">{{ function.label }}</a></li>
     {% endfor %}
 </ul>

--- a/_includes/functions_description.html
+++ b/_includes/functions_description.html
@@ -1,7 +1,7 @@
 <dl>
     {% for function_pair in site.data.functions %}
-    {% assign function = function_pair[1] %}
-    <dt class="function-name">{{ function.label }}</dt>
-    <dd>{{ function.description | markdownify }}</dd>
+        {% assign function = function_pair[1] %}
+        <dt class="function-name">{{ function.label }}</dt>
+        <dd>{{ function.description | markdownify }}</dd>
     {% endfor %}
 </dl>

--- a/_includes/get_bin_name
+++ b/_includes/get_bin_name
@@ -1,1 +1,7 @@
-{% assign fn_parts = include.path | split: '/' | last | split: '.'  %}{% assign fn_parts_size = fn_parts | size %}{% if fn_parts_size < 3 %}{{- fn_parts[0] -}}{% else %}{{- fn_parts[0] -}}.{{- fn_parts[1] -}}{% endif %}
+{% assign fn_parts = include.path | split: '/' | last | split: '.'  %}
+{% assign fn_parts_size = fn_parts | size %}
+{% if fn_parts_size < 3 %}
+    {{- fn_parts[0] -}}
+{% else %}
+    {{- fn_parts[0] -}}.{{- fn_parts[1] -}}
+{% endif %}

--- a/_includes/page_title.html
+++ b/_includes/page_title.html
@@ -1,6 +1,7 @@
 <h1>
+    {% include base.html %}
     {% if page.url != '/' %}
-    <a href="/">..</a> /
+        <a href="{{ base }}/index.html">..</a> /
     {% endif %}
     {{ include.title }}
     <div class="github-buttons">

--- a/_layouts/bin.html
+++ b/_layouts/bin.html
@@ -11,34 +11,31 @@ layout: common
 {{ page.description | markdownify }}
 
 {% for function_pair in site.data.functions %}
-{% assign function_id = function_pair[0] %}
-{% assign function = function_pair[1] %}
-{% assign examples = page.functions[function_id] %}
-{% unless examples %}{% continue %}{% endunless %}
+    {% assign function_id = function_pair[0] %}
+    {% assign function = function_pair[1] %}
+    {% assign examples = page.functions[function_id] %}
+    {% unless examples %}{% continue %}{% endunless %}
 
-<h2 id="{{ function_id }}" class="function-name">{{- function.label -}}</h2>
-{{ function.description | markdownify }}
+    <h2 id="{{ function_id }}" class="function-name">{{- function.label -}}</h2>
+    {{ function.description | markdownify }}
 
-<ul class="examples">
-    {% for example in examples %}
+    <ul class="examples">
+        {% for example in examples %}
+            {% capture code %}
+            {%- if function_id == 'suid' or function_id == 'limited-suid' %}
+                sudo install -m =xs $(which {{ bin_name }}) .
+            {% endif %}
+            {%- if function_id == 'capabilities' %}
+                cp $(which {{ bin_name }}) .
+                sudo setcap cap_setuid+ep {{ bin_name }}
+            {% endif %}
+            {{ example.code | escape }}
+            {% endcapture %}
 
-{% capture code %}
-{%- if function_id == 'suid' or function_id == 'limited-suid' %}
-sudo install -m =xs $(which {{ bin_name }}) .
-{% endif %}
-{%- if function_id == 'capabilities' %}
-cp $(which {{ bin_name }}) .
-sudo setcap cap_setuid+ep {{ bin_name }}
-{% endif %}
-{{ example.code | escape }}
-{% endcapture %}
-
-    <li>
-        {{ example.description | markdownify }}
-        <pre><code>{{- code | strip -}}</code></pre>
-    </li>
-
-    {% endfor %}
-</ul>
-
+            <li>
+                {{ example.description | markdownify }}
+                <pre><code>{{- code | strip -}}</code></pre>
+            </li>
+        {% endfor %}
+    </ul>
 {% endfor %}

--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -4,17 +4,18 @@
         <meta charset="utf-8">
         <title>
             {% if page.url != '/' %}
-            {% if page.layout == 'bin' %}
-            {{ page.title | downcase }}
-            {% else %}
-            {{ page.title }}
-            {% endif %}
+                {% if page.layout == 'bin' %}
+                    {{ page.title | downcase }}
+                {% else %}
+                    {{ page.title }}
+                {% endif %}
             |
             {% endif %}
             {{ site.title }}
         </title>
-        <link rel="icon" href="/assets/logo.png">
-        <link rel="stylesheet" href="/assets/style.css" type="text/css"/>
+        {% include base.html %}
+        <link rel="icon" href="{{ base }}/assets/logo.png">
+        <link rel="stylesheet" href="{{ base }}/assets/style.css" type="text/css"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
         <script async defer src="https://buttons.github.io/buttons.js"></script>
     </head>

--- a/index.md
+++ b/index.md
@@ -3,11 +3,12 @@ layout: page
 title: GTFOBins
 ---
 
-![logo](/assets/logo.png){:.logo}
+{% include base.html %}
+![logo]({{ base }}/assets/logo.png){:.logo}
 
 GTFOBins is a curated list of Unix binaries that can be used to bypass local security restrictions in misconfigured systems.
 
-The project collects legitimate [functions](/functions/) of Unix binaries that can be abused to ~~get the f**k~~ break out restricted shells, escalate or maintain elevated privileges, transfer files, spawn bind and reverse shells, and facilitate the other post-exploitation tasks.
+The project collects legitimate [functions][] of Unix binaries that can be abused to ~~get the f**k~~ break out restricted shells, escalate or maintain elevated privileges, transfer files, spawn bind and reverse shells, and facilitate the other post-exploitation tasks.
 
 It is important to note that this is **not** a list of exploits, and the programs listed here are not vulnerable per se, rather, GTFOBins is a compendium about how to live off the land when you only have certain binaries available.
 
@@ -15,10 +16,10 @@ GTFOBins is a [collaborative][] project created by [Emilio Pinna][norbemi] and [
 
 If you are looking for Windows binaries you should visit [LOLBAS][].
 
-[functions]: /functions/
+[functions]: {{ base }}/functions/index.html
 [LOLBAS]: https://lolbas-project.github.io/
 [collaborative]: https://github.com/GTFOBins/GTFOBins.github.io/graphs/contributors
-[contribute]: /contribute/
+[contribute]: {{ base }}/contribute/index.html
 [norbemi]: https://twitter.com/norbemi
 [cyrus_and]: https://twitter.com/cyrus_and
 


### PR DESCRIPTION
Hello!

Currently GTFOBins requires hosting via HTTP server or be located in the / directory as most of the paths are relative to the root. It does not require many changes to remove this dependent behavior and would make it very portable.
Portable meaning it does not require a HTTP server (i.e. I can browse to where index.html is and everything loads)
This pull request will also make it possible to tag only the _site folder after it is build/compiled.

In this pull request I did the following:
- Added paths relative to root via `base.html`
- Included missing `index.html` references
- Indented if/for loops

I thoroughly tested this with and without a server to make sure all functionality worked correctly.

Let me know if you have any suggestions, feedback, or love/hate it :)