### PR TITLE
Added directory_listing function of diff

### DIFF
--- a/_data/functions.yml
+++ b/_data/functions.yml
@@ -21,10 +21,6 @@ bind-shell:
   label: Bind shell
   description: It can bind a shell to a local port to allow remote network access.
 
-directory-listing:
-  label: Directory listing
-  description: It lists files from folders, it may be used to do privileged listing or disclose folders outside a restricted file system.
-
 non-interactive-bind-shell:
   label: Non-interactive bind shell
   description: It can bind a non-interactive shell to a local port to allow remote network access.

--- a/_data/functions.yml
+++ b/_data/functions.yml
@@ -21,6 +21,10 @@ bind-shell:
   label: Bind shell
   description: It can bind a shell to a local port to allow remote network access.
 
+directory-listing:
+  label: Directory listing
+  description: It lists files from folders, it may be used to do privileged listing or disclose folders outside a restricted file system.
+
 non-interactive-bind-shell:
   label: Non-interactive bind shell
   description: It can bind a non-interactive shell to a local port to allow remote network access.

--- a/_gtfobins/diff.md
+++ b/_gtfobins/diff.md
@@ -4,6 +4,11 @@ functions:
     - code: |
         LFILE=file_to_read
         diff --line-format=%L /dev/null $LFILE
+    - description: This lists the content of a directory. `$TF` can be any directory, but for convenience it is better to use an empty directory to avoid noise output.
+      code: |
+        LFOLDER=folder_to_list
+        TF=$(mktemp -d)
+        diff --recursive $TF $LFOLDER
   suid:
     - code: |
         LFILE=file_to_read
@@ -12,8 +17,4 @@ functions:
     - code: |
         LFILE=file_to_read
         sudo diff --line-format=%L /dev/null $LFILE
-  directory-listing:
-    - code: |
-        LFOLDER=folder_to_list
-        diff --recursive /any/folder $LFOLDER | grep $LFOLDER
 ---

--- a/_gtfobins/diff.md
+++ b/_gtfobins/diff.md
@@ -12,4 +12,8 @@ functions:
     - code: |
         LFILE=file_to_read
         sudo diff --line-format=%L /dev/null $LFILE
+  directory-listing:
+    - code: |
+        LFOLDER=folder_to_list
+        diff --recursive /dev/null $LFOLDER | grep $LFOLDER
 ---

--- a/_gtfobins/diff.md
+++ b/_gtfobins/diff.md
@@ -15,5 +15,5 @@ functions:
   directory-listing:
     - code: |
         LFOLDER=folder_to_list
-        diff --recursive /dev/null $LFOLDER | grep $LFOLDER
+        diff --recursive /any/folder $LFOLDER | grep $LFOLDER
 ---


### PR DESCRIPTION
As the title says, I added the directory_listing function for diff:

```bash
louis@giocondo:~$ export LFOLDER=/home/
louis@giocondo:~$ diff --recursive $LFOLDER /any/folder | grep $LFOLDER
```

gives a list of the folders/files inside of /home/:
```
Only in /home/: louis
```

This function might be useful to find configuration files/source code files in restricted folders.