### PR TITLE
Add LocalCommand option to SSH

### DIFF
--- a/_gtfobins/ssh.md
+++ b/_gtfobins/ssh.md
@@ -5,6 +5,8 @@ functions:
       code: ssh localhost $SHELL --noprofile --norc
     - description: Spawn interactive shell through ProxyCommand option.
       code: ssh -o ProxyCommand=';sh 0<&2 1>&2' x
+    - description: Spawn interactive shell on client - requires successful connection.
+      code: ssh -oPermitLocalCommand=yes -oLocalCommand=bash x
   file-upload:
     - description: Send local file to a SSH server.
       code: |

--- a/_gtfobins/ssh.md
+++ b/_gtfobins/ssh.md
@@ -5,8 +5,8 @@ functions:
       code: ssh localhost $SHELL --noprofile --norc
     - description: Spawn interactive shell through ProxyCommand option.
       code: ssh -o ProxyCommand=';sh 0<&2 1>&2' x
-    - description: Spawn interactive shell on client - requires successful connection.
-      code: ssh -oPermitLocalCommand=yes -oLocalCommand=bash x
+    - description: Spawn interactive shell on client, requires a successful connection towards `host`.
+      code: ssh -o PermitLocalCommand=yes -o LocalCommand=/bin/sh host
   file-upload:
     - description: Send local file to a SSH server.
       code: |


### PR DESCRIPTION
SSH has a LocalCommand option that will run a given command on the client machine after a successful connection.  It is generally disabled, but can be enabled on the command line with "-oPermitLocalCommand=yes".  This is useful for bypassing restricted shells.