### PR TITLE
Update ld.so.md

### DIFF
--- a/_gtfobins/ld.so.md
+++ b/_gtfobins/ld.so.md
@@ -6,6 +6,7 @@ description: |
   $ strings /proc/self/exe | head -1
   /lib64/ld-linux-x86-64.so.2
   ```
+  It's worth noting that the spawned process doesn't get it's own pid and isn't exposed via `/proc/$PID/exe` on kernel 6.2.12-060212-generic as of 20230526 see https://shyft.us/posts/20230526_linux_command_proxy.html for more information. 
 functions:
   shell:
     - code: /lib/ld.so /bin/sh

--- a/_gtfobins/ld.so.md
+++ b/_gtfobins/ld.so.md
@@ -6,7 +6,8 @@ description: |
   $ strings /proc/self/exe | head -1
   /lib64/ld-linux-x86-64.so.2
   ```
-  It's worth noting that the spawned process doesn't get it's own pid and isn't exposed via `/proc/$PID/exe` on kernel 6.2.12-060212-generic as of 20230526 see https://shyft.us/posts/20230526_linux_command_proxy.html for more information. 
+
+  It's worth noting that the spawned process will be the loader, not the target executable, this might aid evasion. See https://shyft.us/posts/20230526_linux_command_proxy.html for more information.
 functions:
   shell:
     - code: /lib/ld.so /bin/sh


### PR DESCRIPTION
I noticed that `ld.so` was the exe linked to in /proc/pid/exe rather than my binary.

That obfuscates where my code is running. My code is given the PID of `ld.so` but isn't pointed to in except in /proc/pid/map_files 

my post gives more information about leveraging that in an offensive context. https://shyft.us/posts/20230526_linux_command_proxy.html