### PR TITLE
adding sudo

### DIFF
--- a/_gtfobins/sudo.md
+++ b/_gtfobins/sudo.md
@@ -1,0 +1,5 @@
+---
+functions:
+    sudo:
+    - code: sudo sudo /bin/sh
+---

--- a/_gtfobins/sudo.md
+++ b/_gtfobins/sudo.md
@@ -1,5 +1,5 @@
 ---
 functions:
-    sudo:
+  sudo:
     - code: sudo sudo /bin/sh
 ---


### PR DESCRIPTION
I'll be honest... I know this seems silly - but I just observed a curious behavior by an asset discovery system which prompted me to document this.

The asset discovery system is running a command like
```sudo sudo -p ************* lsof -iTCP -n -P -F pcnfT```

I think this might be an bug in their command generation... but then it occurred to me that if this command works it might be because of a rule like:
```dev     ALL=NOPASSWD: /usr/bin/sudo``` as opposed to the more expected ```dev     ALL=NOPASSWD: /usr/sbin/lsof``` or something.

make me a sandwich -> access denied
sudo make me a sandwich -> access denied
sudo sudo make me a sandwich -> okay