### PR TITLE
Patched by Nagios Plugins project

### DIFF
--- a/_gtfobins/check_by_ssh.md
+++ b/_gtfobins/check_by_ssh.md
@@ -1,6 +1,12 @@
 ---
 description: |
   This is the `check_by_ssh` Nagios plugin, available e.g. in `/usr/lib/nagios/plugins/`.
+
+  When `check_by_ssh` version `2.4.5` (2023-05-31) or later from the Nagios
+  Plugins project in it's default configuration is used, it does not work anymore.
+
+  It does still work on previous versions from the Nagios Plugins project or
+  all versions from the Monitoring Project (e.g. used by Ubuntu/Debian).
 functions:
   shell:
     - description: The shell will only last 10 seconds.


### PR DESCRIPTION
Hi

When `check_by_ssh` version `2.4.5` (2023-05-31) or later from the Nagios  Plugins project in it's default configuration is used, it does not work anymore.

It does still work on previous versions from the Nagios Plugins project or   all versions from the Monitoring Project (e.g. used by Ubuntu/Debian).

References:
- Patch: https://github.com/nagios-plugins/nagios-plugins/commit/e8810de21be80148562b7e0168b0a62aeedffde6
- Source: https://joshua.hu/nagios-hacking-cve-2023-37154

Best,
Mänu