### PR TITLE
ncdu.md

### DIFF
--- a/_gtfobins/ncdu.md
+++ b/_gtfobins/ncdu.md
@@ -1,0 +1,14 @@
+---
+functions:
+  shell:
+    - description: The `ncdu` is interactive, so after runing push key `b` spawning shell.
+    - code: |
+        ncdu
+        b
+  sudo:
+    - code: |
+        sudo ncdu
+        b
+---
+
+

--- a/_gtfobins/ncdu.md
+++ b/_gtfobins/ncdu.md
@@ -1,13 +1,16 @@
 ---
 functions:
   shell:
-    - description: The `ncdu` is interactive, so after runing push key `b` spawning shell.
     - code: |
         ncdu
         b
   sudo:
     - code: |
         sudo ncdu
+        b
+  limited-suid:
+    - code: |
+        ./ncdu
         b
 ---
 


### PR DESCRIPTION
Program by default has option for spawning interactive shell.
Can be used for bypass restriction of shell and sudo for gain to root.

Ncdu will determine your preferred shell from the "NCDU_SHELL" or "SHELL" variable (in that order), or will call "/bin/sh" if neither are set.
 export NCDU_SHELL=/bin/bash
 ncdu