### PR TITLE
Add exec

### DIFF
--- a/_gtfobins/exec.md
+++ b/_gtfobins/exec.md
@@ -1,12 +1,12 @@
 ---
 functions:
   file-read:
-    - description: Read arbitrary files using 'exec' and 'tr' to remove null bytes (if any).
+    - description: Read arbitrary files using 'exec' and 'tr'.
       code: |
         TF=$(mktemp)
         echo '#!/bin/sh' > $TF
         echo 'export LFILE="file_to_read"' >> $TF
-        echo 'exec < "$LFILE"; tr -d "\0"' >> $TF
+        echo 'exec < "$LFILE"; tr -d ""' >> $TF
         chmod +x $TF
         $TF
 ---

--- a/_gtfobins/exec.md
+++ b/_gtfobins/exec.md
@@ -1,0 +1,12 @@
+---
+functions:
+  file-read:
+    - description: Read arbitrary files using 'exec' and 'tr' to remove null bytes (if any).
+      code: |
+        TF=$(mktemp)
+        echo '#!/bin/sh' > $TF
+        echo 'export LFILE="file_to_read"' >> $TF
+        echo 'exec < "$LFILE"; tr -d "\0"' >> $TF
+        chmod +x $TF
+        $TF
+---


### PR DESCRIPTION
This method offers an unconventional file reading approach using 'exec' and 'tr' to remove null bytes.

It can be handy in restricted environments where typical file reading commands like 'cat' are restricted or monitored.

In my tests, I had to create a .sh script from this code to prevent it from exiting and closing the shell.

<img width="897" alt="Screenshot 2023-12-18 at 04 33 14" src="https://github.com/GTFOBins/GTFOBins.github.io/assets/112820741/44ffbb4c-0e79-4bc3-8a44-25d33ce8061a">
