### PR TITLE
Add tr

### DIFF
--- a/_gtfobins/tr.md
+++ b/_gtfobins/tr.md
@@ -1,0 +1,8 @@
+---
+description: The read file content is binary-safe.
+functions:
+  file-read:
+    - code: |
+        export LFILE="file_to_read"
+        (exec < "$LFILE"; tr -d "")
+---


### PR DESCRIPTION
Hello,

Here's an alternative approach for reading files, utilizing shell builtin commands along with the `tr` binary.
It's useful in scenarios where common file-reading utilities like `cat` might be restricted or monitored.

The read file approach is binary-safe.
The use of a subshell is needed to avoid shutting down the main interactive shell when `exec` is done.

Proof of Concept:
<img width="1014" alt="Screenshot 2023-12-18 at 19 04 32" src="https://github.com/GTFOBins/GTFOBins.github.io/assets/112820741/42552368-e6e0-41bc-8046-591f8b5156c7">

This submission builds on the previous PR #430 .
I've taken the feedback and made tweaks for a better fit.

Thank you,
taki
