### PR TITLE
Create dnsmasq.md

### DIFF
--- a/_gtfobins/dnsmasq.md
+++ b/_gtfobins/dnsmasq.md
@@ -1,0 +1,6 @@
+---
+functions:
+  sudo:
+    - code: |
+        dnsmasq --conf-script=./script.sh
+---


### PR DESCRIPTION
![image](https://github.com/GTFOBins/GTFOBins.github.io/assets/68353531/6bc69786-1e9e-43c2-89e4-b243eb1ceaa8)


In test case, the user with sudo rights to dnsmasq was able to execute the bash script using the intended --conf-script flag.
Contents of test.sh
```
cp /root/flag.txt /tmp/flag.txt
```