### PR TITLE
Nano SUID Fix

### DIFF
--- a/_gtfobins/nano.md
+++ b/_gtfobins/nano.md
@@ -20,8 +20,8 @@ functions:
   limited-suid:
     - description: The `SPELL` environment variable can be used in place of the `-s` option if the command line cannot be changed.
       code: |
-        ./nano -s /bin/sh
-        /bin/sh
+        ./nano -s "/bin/sh -p"
+        /bin/sh -p
         ^T
   sudo:
     - code: |


### PR DESCRIPTION
nano needs -p when used as suid to get a shell:

![image](https://github.com/GTFOBins/GTFOBins.github.io/assets/67713732/47e67426-da1f-4b72-91db-b34f653e0a05)
