### PR TITLE
[Update] Run-parts

### DIFF
--- a/_gtfobins/run-parts.md
+++ b/_gtfobins/run-parts.md
@@ -6,4 +6,10 @@ functions:
     - code: sudo run-parts --new-session --regex '^sh$' /bin
   suid:
     - code: ./run-parts --new-session --regex '^sh$' /bin --arg='-p'
+  command:
+    - description: Execute all executable scripts in a specified directory. In this case, the command runs all scripts in `/tmp/run-parts/`.
+      code: |
+        mkdir -p /tmp/run-parts/
+        printf '#!/bin/sh\n/bin/sh -c "/bin/id > /tmp/id.out"\n' > /tmp/run-parts/id && chmod +x /tmp/run-parts/id
+        run-parts /tmp/run-parts
 ---


### PR DESCRIPTION
## Summary
This PR adds command execution capabilities to the `run-parts` binary. Run-parts is capable of executing shell scripts, which allows for proxied command execution. 

```
> root@vm:/home/ruben_groenewoud# printf '#!/bin/sh\n/bin/sh -c "/bin/id > /tmp/id.out"\n' > /tmp/run-parts/id && chmod +x /tmp/run-parts/id

> root@vm:/home/ruben_groenewoud# cat /tmp/run-parts/id 

#!/bin/sh
/bin/sh -c "/bin/id > /tmp/id.out"

> root@vm:/home/ruben_groenewoud# run-parts /tmp/run-parts

> root@vm:/home/ruben_groenewoud# cat /tmp/id.out 

uid=0(root) gid=0(root) groups=0(root)
```