### PR TITLE
Add 'file write' capability to 'sort'

### DIFF
--- a/_gtfobins/sort.md
+++ b/_gtfobins/sort.md
@@ -4,6 +4,10 @@ functions:
     - code: |
         LFILE=file_to_read
         sort -m "$LFILE"
+  file-write:
+    - code: |
+        LFILE=file_to_write
+        echo DATA | sort -o "$LFILE"
   suid:
     - code: |
         LFILE=file_to_read


### PR DESCRIPTION
[As described in POSIX](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/sort.html), `sort` has a flag that can be used to write to files:

```
-o  output
    Specify the name of an output file to be used instead of the standard output. This file can be
    the same as one of the input files.
```