### PR TITLE
New GTFOBin: getent for extracting privileged NSS entries via SUID

### DIFF
--- a/_gtfobins/getent.md
+++ b/_gtfobins/getent.md
@@ -1,0 +1,18 @@
+---
+description: |
+  `getent` is a utility that retrieves entries from administrative databases configured 
+  via the Name Service Switch (NSS). If misconfigured with the SUID bit, it can be abused 
+  to access sensitive databases such as `shadow`, which contains user password hashes, 
+  including root's.
+
+  This can lead to local privilege escalation by leaking password hashes for offline cracking.
+
+functions:
+  suid:
+    - code: |
+        # Leak root hash from /etc/shadow via getent SUID binary
+        ./getent shadow root
+    - code: |
+        # Dump all hashes
+        ./getent shadow
+---


### PR DESCRIPTION
---
description: |
  `getent` is a command-line utility used to fetch entries from administrative databases 
  configured in the system’s Name Service Switch (NSS), such as `passwd`, `group`, `hosts`, 
  and critically, `shadow`. While most of these databases are readable by regular users, 
  the `shadow` database is highly sensitive, containing hashed passwords for all system 
  accounts, including `root`.

  Under normal circumstances, `getent` requires root privileges to access the `shadow` database. 
  However, if the `getent` binary has the SUID bit set, a low-privileged user can abuse it to 
  retrieve password hashes, thus violating the integrity of the authentication system.

  The attacker can extract these hashes and then perform offline cracking using tools like 
  `john` or `hashcat`. This is a stealthy and shell-less method of privilege escalation that 
  works in restricted environments and minimal systems where only core utilities exist.

  This abuse works without invoking an interactive shell, interpreter, or script engine, and 
  relies purely on the logic of `getent` and the SUID bit — making it a candidate for 
  inclusion in GTFOBins under the `suid` vector.

  Example:
  ```bash
  ./getent shadow root
  # root:$6$saltsalt$abc...xyz:19429:0:99999:7:::