### PR TITLE
Fix command syntax in tcpdump instructions

### DIFF
--- a/_gtfobins/tcpdump
+++ b/_gtfobins/tcpdump
@@ -10,7 +10,7 @@ functions:
     contexts:
       sudo:
         code: |-
-          echo /path/to/command" >/path/to/temp-file
+          echo /path/to/command >/path/to/temp-file
           chmod +x /path/to/temp-file
           tcpdump -ln -i lo -w /dev/null -W 1 -G 1 -z /path/to/temp-file -Z root
       unprivileged:


### PR DESCRIPTION
Fix: remove stray double quote in tcpdump sudo command example

The tcpdump entry (command → sudo) contains an extra double quote which breaks the command syntax. This PR removes the stray quote to make the example executable as intended.

Original:
`echo /path/to/command" >/path/to/temp-file`

Fixed:
`echo /path/to/command >/path/to/temp-file`

