### PR TITLE
more sensible Dockerfile for portable image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.3.4
 
 WORKDIR /GTFOBins/
 
-COPY ./Gemfile ./
+COPY . .
 
 RUN bundle install
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ serve:
 		--rm \
 		--name "$(NAME)" \
 		--publish "$(PORT):$(PORT)" \
-		--volume "$$PWD/:/GTFOBins/" \
 		"$(NAME)" 2>&1 \
 		| grep -v "Error: could not read file /GTFOBins/_gtfobins/.*: undefined method \`split' for nil"
 


### PR DESCRIPTION
currently `make serve` won't create a usable local image because bind-mounted pwd overwrites the installed bundles in `docker build` image
```
podman run -it -p 4000:4000 --rm -v $(pwd)/:/GTFOBins/ gtfobins
Could not find nokogiri-1.19.0-x86_64-linux-gnu, addressable-2.8.8, typhoeus-1.5.0, faraday-2.14.0, ethon-0.15.0, execjs-2.10.0, activesupport-8.1.2, json-2.18.0, ffi-1.17.3-x86_64-linux-gnu, bigdecimal-4.0.1, minitest-6.0.1, prism-1.8.0 in locally installed gems
Run `bundle install` to install missing gems.
```
caused by 7505534f194888a2b598f845da14f71103e17216

Also, it don't make sense to cd into the repo's repository and bind-mount. It would be nice to run it with a single `podman run --rm -p 4000:4000 gtfobins` in ANY directory

