### PR TITLE
Fix syntax error in nginx config file payload

### DIFF
--- a/_gtfobins/nginx
+++ b/_gtfobins/nginx
@@ -26,7 +26,7 @@ functions:
   library-load:
   - code: |-
       cat >/path/to/temp-file <<EOF
-      load_module /path/to/lib.so
+      load_module /path/to/lib.so;
       EOF
 
       nginx -t -c /path/to/temp-file


### PR DESCRIPTION
The original payload missing semicolon causes nginx configuration file test failure.
```
2026/05/15 10:17:22 [emerg] 1210#1210: unexpected end of file, expecting ";" or "}" in /home/user/tmpfile:2
nginx: configuration file /home/user/tmpfile test failed
```
My commit fixes the issue