### PR TITLE
Add du

### DIFF
--- a/_gtfobins/du
+++ b/_gtfobins/du
@@ -1,0 +1,14 @@
+---
+functions:
+  file-read:
+  - binary: false
+    code: |-
+      du --files0-from=/path/to/input-file
+    comment: |-
+      du will open and parse the file as a NUL-delimited list of paths.
+      File contents are leaked as error messages in stderr `du: cannot access '<file contents>': File name too long`
+    contexts:
+      sudo:
+      suid:
+      unprivileged:
+...


### PR DESCRIPTION
`du` is a standard coreutils utility for estimating file space usage, commonly available on all Unix-like systems.

The `--files0-from` option reads a NUL-delimited list of file paths from a specified file. Each entry is stat'd and measured. Non-existent paths are emitted as error messages to stderr, leaking each line of the input file.

Content is leaked via stderr error messages of the form `du: cannot access '<file contents>': No such file or directory`.