### PR TITLE
Add groovy

### DIFF
--- a/_gtfobins/groovy
+++ b/_gtfobins/groovy
@@ -1,0 +1,9 @@
+---
+functions:
+  shell:
+  - code: |-
+      groovy -e 'new ProcessBuilder(["/bin/sh"]).inheritIO().start().waitFor();'
+    contexts:
+      sudo:
+      unprivileged:
+...


### PR DESCRIPTION
Added `groovy` entry.
The `-e` option of the binary can be used to spawn an interactive system shell.