### PR TITLE
Add tzupdate

### DIFF
--- a/_gtfobins/tzupdate
+++ b/_gtfobins/tzupdate
@@ -1,0 +1,12 @@
+---
+functions:
+  file-write:
+  - code: |-
+      echo DATA > /path/to/temp-dir/tz
+      tzupdate -t tz -z /path/to/temp-dir/ -l /path/to/output-file
+    comment: |-
+      The output file must already exist and is replaced by a symlink to `/path/to/temp-dir/tz`. Use `-d /path/to/temp-file` to avoid also overwriting `/etc/timezone` on Debian-based systems.
+    contexts:
+      sudo:
+      unprivileged:
+...


### PR DESCRIPTION
tzupdate maintains the `/etc/localtime` symlink. `-l` sets the path the symlink is written to and `-z` the directory it points into, so it can replace an existing file with one whose contents the caller controls. `-t` takes the zone name directly, which avoids the network geolocation lookup.

Tested on Arch (tzupdate 3.1.0, Rust) and on Debian 12 and Fedora 41 (PyPI, Python). The relevant flags are identical in both implementations.
