### PR TITLE
Remove invalid unprivileged context from podman

### DIFF
--- a/_gtfobins/podman
+++ b/_gtfobins/podman
@@ -7,5 +7,4 @@ functions:
       This requires an actual image to be available (e.g., `alpine`) downloading it if not present.
     contexts:
       sudo:
-      unprivileged:
 ...


### PR DESCRIPTION
The podman entry is currently marked as available in the unprivileged context.
Rootless Podman uses user namespaces, so `--privileged` does not provide the container with privileges beyond those of the invoking host user -> Therefore, this technique should not be listed under the `unprivileged` context.

This removes the invalid `unprivileged` context while keeping the existing `sudo` context

Fixes #587